### PR TITLE
bump @conform-to/dom from 0.9.1 to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.3.3",
-        "@conform-to/dom": "^0.9.1",
+        "@conform-to/dom": "^1.0.0",
         "@tsconfig/node16": "^16.1.1",
         "semantic-release": "^22.0.8",
         "tsup": "^8.0.0",
@@ -19,7 +19,7 @@
         "vitest": "^0.34.6"
       },
       "peerDependencies": {
-        "@conform-to/dom": "^0.9.1",
+        "@conform-to/dom": "^1.0.0",
         "valibot": "^0.27.0"
       }
     },
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@conform-to/dom": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@conform-to/dom/-/dom-0.9.1.tgz",
-      "integrity": "sha512-+T6QgpLDPZ29j4y5nWW61WMe8qj0cQBymyzbi5sq1f3CcBO3wBbR0VPI7mbm+rLoErHWM3ghhdNlIkw0UPoLLA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@conform-to/dom/-/dom-1.0.0.tgz",
+      "integrity": "sha512-KG0Ee2G9BcFLdqtpcexdht48QNM2F9ddAyJFSHNG4V3e2QOmVEAM7M6R/iWWykpTVQljWmKd2J7U4ep/7/XRrA==",
       "dev": true
     },
     "node_modules/@esbuild/android-arm": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "valibot"
   ],
   "peerDependencies": {
-    "@conform-to/dom": "^0.9.1",
+    "@conform-to/dom": "^1.0.0",
     "valibot": "^0.27.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.3.3",
-    "@conform-to/dom": "^0.9.1",
+    "@conform-to/dom": "^1.0.0",
     "@tsconfig/node16": "^16.1.1",
     "semantic-release": "^22.0.8",
     "tsup": "^8.0.0",

--- a/parse.ts
+++ b/parse.ts
@@ -1,4 +1,9 @@
-import { type Submission, getName, parse as baseParse } from "@conform-to/dom";
+import {
+  type Intent,
+  type Submission,
+  formatPaths,
+  parse as baseParse,
+} from "@conform-to/dom";
 import {
   type BaseSchema,
   type Output,
@@ -22,10 +27,10 @@ export function parse<Schema extends BaseSchema & { type: string }>(
 export function parse<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
-    schema: Schema | ((intent: string) => Schema);
+    schema: Schema | ((intent: Intent | null) => Schema);
   },
 ): Submission<Output<Schema>> | Promise<Submission<Output<Schema>>> {
-  return baseParse<Output<Schema>>(payload, {
+  return baseParse<Output<Schema>, string[]>(payload, {
     resolve(payload, intent) {
       const schema = enableTypeCoercion(
         typeof config.schema === "function"
@@ -45,7 +50,7 @@ export function parse<Schema extends BaseSchema & { type: string }>(
         return {
           error: result.issues.reduce<Record<string, string[]>>((result, e) => {
             const name = e.path
-              ? getName(e.path.map((d) => d.key as string | number))
+              ? formatPaths(e.path.map((d) => d.key as string | number))
               : (e.input as string | number);
 
             result[name] = [...(result[name] ?? []), e.message];

--- a/tests/any.test.ts
+++ b/tests/any.test.ts
@@ -8,10 +8,16 @@ describe("any", () => {
     const schema = object({ item: any() });
     const input1 = createFormData("item", "hello");
     const output1 = parse(input1, { schema });
-    expect(output1).toMatchObject({ error: {}, value: { item: "hello" } });
+    expect(output1).toMatchObject({
+      status: "success",
+      value: { item: "hello" },
+    });
     const input2 = createFormData("item", "1");
     input2.append("item", "2");
     const output2 = parse(input2, { schema });
-    expect(output2).toMatchObject({ error: {}, value: { item: ["1", "2"] } });
+    expect(output2).toMatchObject({
+      status: "success",
+      value: { item: ["1", "2"] },
+    });
   });
 });

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -12,7 +12,7 @@ describe("array", () => {
     const output = parse(formData, { schema });
 
     expect(output).toMatchObject({
-      error: {},
+      status: "success",
       value: { select: ["1", "2", "3"] },
     });
   });

--- a/tests/boolean.test.ts
+++ b/tests/boolean.test.ts
@@ -8,7 +8,10 @@ describe("boolean", () => {
     const schema = object({ check: boolean() });
     const input1 = createFormData("check", "on");
     const output1 = parse(input1, { schema });
-    expect(output1).toMatchObject({ error: {}, value: { check: true } });
+    expect(output1).toMatchObject({
+      status: "success",
+      value: { check: true },
+    });
     expect(parse(createFormData("check", ""), { schema })).toMatchObject({
       error: { check: ["Invalid type"] },
     });

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -8,7 +8,7 @@ describe("date", () => {
     const schema = object({ birthday: date() });
     const output = parse(createFormData("birthday", "2023-11-19"), { schema });
     expect(output).toMatchObject({
-      error: {},
+      status: "success",
       value: { birthday: new Date("2023-11-19") },
     });
 

--- a/tests/enum.test.ts
+++ b/tests/enum.test.ts
@@ -15,14 +15,14 @@ describe("enum_", () => {
     const formData1 = createFormData("item", Direction.Left);
     const output1 = parse(formData1, { schema });
     expect(output1).toMatchObject({
-      error: {},
+      status: "success",
       value: { item: Direction.Left },
     });
 
     const formData2 = createFormData("item", Direction.Right);
     const output2 = parse(formData2, { schema });
     expect(output2).toMatchObject({
-      error: {},
+      status: "success",
       value: { item: Direction.Right },
     });
 

--- a/tests/nonNullish.test.ts
+++ b/tests/nonNullish.test.ts
@@ -17,7 +17,7 @@ describe("nonOptional", () => {
     });
     const input1 = createFormData("item", "1");
     const output1 = parse(input1, { schema: schema1 });
-    expect(output1).toMatchObject({ error: {}, value: { item: 1 } });
+    expect(output1).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
       parse(createFormData("item", "non Number"), { schema: schema1 }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
@@ -29,7 +29,7 @@ describe("nonOptional", () => {
       item: nonNullish(union([number(), undefined_()])),
     });
     const output2 = parse(input1, { schema: schema2 });
-    expect(output2).toMatchObject({ error: {}, value: { item: 1 } });
+    expect(output2).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
       parse(createFormData("item", "non Number"), { schema: schema2 }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });

--- a/tests/nonOptional.test.ts
+++ b/tests/nonOptional.test.ts
@@ -17,7 +17,7 @@ describe("nonOptional", () => {
     });
     const input1 = createFormData("item", "1");
     const output1 = parse(input1, { schema: schema1 });
-    expect(output1).toMatchObject({ error: {}, value: { item: 1 } });
+    expect(output1).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
       parse(createFormData("item", "non Number"), { schema: schema1 }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
@@ -29,7 +29,7 @@ describe("nonOptional", () => {
       item: nonOptional(union([number(), undefined_()])),
     });
     const output2 = parse(input1, { schema: schema2 });
-    expect(output2).toMatchObject({ error: {}, value: { item: 1 } });
+    expect(output2).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
       parse(createFormData("item", "non Number"), { schema: schema2 }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });

--- a/tests/nullable.ts
+++ b/tests/nullable.ts
@@ -8,9 +8,12 @@ describe("nullable", () => {
     const schema = object({ age: nullable(number()) });
     const output = parse(createFormData("age", ""), { schema });
 
-    expect(output).toMatchObject({ error: {}, value: { age: undefined } });
+    expect(output).toMatchObject({
+      status: "success",
+      value: { age: undefined },
+    });
     expect(parse(createFormData("age", "20"), { schema })).toMatchObject({
-      error: {},
+      status: "success",
       value: { age: 20 },
     });
     expect(
@@ -23,10 +26,16 @@ describe("nullable", () => {
 
     const schema1 = object({ name: nullable(string(), default_) });
     const output1 = parse(createFormData("name", ""), { schema: schema1 });
-    expect(output1).toMatchObject({ error: {}, value: { name: "default" } });
+    expect(output1).toMatchObject({
+      status: "success",
+      value: { name: "default" },
+    });
 
     const schema2 = object({ name: nullable(string(), () => default_) });
     const output2 = parse(createFormData("name", ""), { schema: schema1 });
-    expect(output2).toMatchObject({ error: {}, value: { name: "default" } });
+    expect(output2).toMatchObject({
+      status: "success",
+      value: { name: "default" },
+    });
   });
 });

--- a/tests/nullish.test.ts
+++ b/tests/nullish.test.ts
@@ -8,9 +8,12 @@ describe("nullish", () => {
     const schema = object({ age: nullish(number()) });
     const output = parse(createFormData("age", ""), { schema });
 
-    expect(output).toMatchObject({ error: {}, value: { age: undefined } });
+    expect(output).toMatchObject({
+      status: "success",
+      value: { age: undefined },
+    });
     expect(parse(createFormData("age", "20"), { schema })).toMatchObject({
-      error: {},
+      status: "success",
       value: { age: 20 },
     });
     expect(
@@ -23,10 +26,16 @@ describe("nullish", () => {
 
     const schema1 = object({ name: nullish(string(), default_) });
     const output1 = parse(createFormData("name", ""), { schema: schema1 });
-    expect(output1).toMatchObject({ error: {}, value: { name: "default" } });
+    expect(output1).toMatchObject({
+      status: "success",
+      value: { name: "default" },
+    });
 
     const schema2 = object({ name: nullish(string(), () => default_) });
     const output2 = parse(createFormData("name", ""), { schema: schema1 });
-    expect(output2).toMatchObject({ error: {}, value: { name: "default" } });
+    expect(output2).toMatchObject({
+      status: "success",
+      value: { name: "default" },
+    });
   });
 });

--- a/tests/number.test.ts
+++ b/tests/number.test.ts
@@ -8,7 +8,7 @@ describe("number", () => {
     const schema = object({ age: number() });
     const output = parse(createFormData("age", "20"), { schema });
 
-    expect(output).toMatchObject({ error: {}, value: { age: 20 } });
+    expect(output).toMatchObject({ status: "success", value: { age: 20 } });
     expect(parse(createFormData("age", ""), { schema })).toMatchObject({
       error: { age: ["Invalid type"] },
     });

--- a/tests/optional.test.ts
+++ b/tests/optional.test.ts
@@ -8,9 +8,12 @@ describe("optional", () => {
     const schema = object({ age: optional(number()) });
     const output = parse(createFormData("age", ""), { schema });
 
-    expect(output).toMatchObject({ error: {}, value: { age: undefined } });
+    expect(output).toMatchObject({
+      status: "success",
+      value: { age: undefined },
+    });
     expect(parse(createFormData("age", "20"), { schema })).toMatchObject({
-      error: {},
+      status: "success",
       value: { age: 20 },
     });
     expect(
@@ -23,10 +26,16 @@ describe("optional", () => {
 
     const schema1 = object({ name: optional(string(), default_) });
     const output1 = parse(createFormData("name", ""), { schema: schema1 });
-    expect(output1).toMatchObject({ error: {}, value: { name: "default" } });
+    expect(output1).toMatchObject({
+      status: "success",
+      value: { name: "default" },
+    });
 
     const schema2 = object({ name: optional(string(), () => default_) });
     const output2 = parse(createFormData("name", ""), { schema: schema2 });
-    expect(output2).toMatchObject({ error: {}, value: { name: "default" } });
+    expect(output2).toMatchObject({
+      status: "success",
+      value: { name: "default" },
+    });
   });
 });

--- a/tests/picklist.test.ts
+++ b/tests/picklist.test.ts
@@ -10,14 +10,14 @@ describe("picklist", () => {
     const formData1 = createFormData("list", "value_1");
     const output1 = parse(formData1, { schema });
     expect(output1).toMatchObject({
-      error: {},
+      status: "success",
       value: { list: "value_1" },
     });
 
     const formData2 = createFormData("list", "value_2");
     const output2 = parse(formData2, { schema });
     expect(output2).toMatchObject({
-      error: {},
+      status: "success",
       value: { list: "value_2" },
     });
 

--- a/tests/pipe.test.ts
+++ b/tests/pipe.test.ts
@@ -7,6 +7,6 @@ describe("pipe", () => {
   test("should pass also undefined", () => {
     const schema = object({ name: optional(nullable(string()), null) });
     const output = parse(createFormData("name", ""), { schema });
-    expect(output).toMatchObject({ error: {}, value: { name: null } });
+    expect(output).toMatchObject({ status: "success", value: { name: null } });
   });
 });

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -9,7 +9,10 @@ describe("string", () => {
 
     const output = parse(createFormData("name", "Jane"), { schema });
 
-    expect(output).toMatchObject({ error: {}, value: { name: "Jane" } });
+    expect(output).toMatchObject({
+      status: "success",
+      value: { name: "Jane" },
+    });
     expect(parse(createFormData("name", ""), { schema })).toMatchObject({
       error: { name: ["Invalid type"] },
     });

--- a/tests/undefined.test.ts
+++ b/tests/undefined.test.ts
@@ -8,13 +8,13 @@ describe("undefined", () => {
     const schema = object({ name: string(), age: undefined_() });
     const formData1 = createFormData("name", "Jane");
     expect(parse(formData1, { schema })).toMatchObject({
-      error: {},
+      status: "success",
       value: { name: "Jane" },
     });
 
     formData1.append("age", "");
     expect(parse(formData1, { schema })).toMatchObject({
-      error: {},
+      status: "success",
       value: { name: "Jane", age: undefined },
     });
 

--- a/tests/union.test.ts
+++ b/tests/union.test.ts
@@ -7,10 +7,13 @@ describe("union", () => {
   test("should pass only union values", () => {
     const schema = object({ age: union([number(), undefined_()]) });
     const output1 = parse(createFormData("age", "30"), { schema });
-    expect(output1).toMatchObject({ error: {}, value: { age: 30 } });
+    expect(output1).toMatchObject({ status: "success", value: { age: 30 } });
 
     const output2 = parse(createFormData("age", ""), { schema });
-    expect(output2).toMatchObject({ error: {}, value: { age: undefined } });
+    expect(output2).toMatchObject({
+      status: "success",
+      value: { age: undefined },
+    });
 
     expect(
       parse(createFormData("age", "non number"), { schema }),


### PR DESCRIPTION
Hi. At first, I would say thank you for your library.

Conform has reached v1, and there were changes in types and APIs, which made this library unusable.
So I fixed them. This includes breaking changes.
