### PR TITLE
fix: change parse function name to parseWithValibot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ $ npm install @conform-to/react valibot conform-to-valibot
 
 ## API Reference
 
-- [parse](#parse)
+- [parseWithValibot](#parseWithValibot)
 
 <!-- /aside -->
 
-### parse
+### parseWithValibot
 
 It parses the formData and returns a submission result with the validation error. If no error is found, the parsed data will also be populated as `submission.value`.
 
 ```tsx
 import { useForm } from '@conform-to/react';
-import { parse } from 'conform-to-valibot';
+import { parseWithValibot } from 'conform-to-valibot';
 import { object, string } from 'valibot';
 
 const schema = object({
@@ -38,7 +38,7 @@ const schema = object({
 function ExampleForm() {
   const [form, { email, password }] = useForm({
     onValidate({ formData }) {
-      return parse(formData, {
+      return parseWithValibot(formData, {
         schema,
       });
     },
@@ -52,7 +52,7 @@ Or when parsing the formData on server side (e.g. Remix):
 
 ```tsx
 import { useForm } from '@conform-to/react';
-import { parse } from 'conform-to-valibot';
+import { parseWithValibot } from 'conform-to-valibot';
 import { object } from 'valibot';
 
 const schema = object({
@@ -61,12 +61,13 @@ const schema = object({
 
 export async function action({ request }) {
   const formData = await request.formData();
-  const submission = await parse(formData, {
+  const submission = await parseWithValibot(formData, {
     schema,
   });
 
-  if (!submission.value || submission.intent !== 'submit') {
-    return submission;
+  // Send the submission back to the client if the status is not successful
+  if (submission.status !== 'success') {
+    return submission.reply();
   }
 
   // ...

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export { parse } from "./parse";
+export { parseWithValibot } from "./parse";

--- a/parse.ts
+++ b/parse.ts
@@ -12,19 +12,19 @@ import {
 } from "valibot";
 import { enableTypeCoercion } from "./coercion";
 
-export function parse<Schema extends BaseSchema & { type: string }>(
+export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
   },
 ): Submission<Output<Schema>>;
-export function parse<Schema extends BaseSchema & { type: string }>(
+export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
   },
 ): Promise<Submission<Output<Schema>>>;
-export function parse<Schema extends BaseSchema & { type: string }>(
+export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: Intent | null) => Schema);

--- a/tests/any.test.ts
+++ b/tests/any.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, any } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
@@ -7,14 +7,14 @@ describe("any", () => {
   test("should pass any values", () => {
     const schema = object({ item: any() });
     const input1 = createFormData("item", "hello");
-    const output1 = parse(input1, { schema });
+    const output1 = parseWithValibot(input1, { schema });
     expect(output1).toMatchObject({
       status: "success",
       value: { item: "hello" },
     });
     const input2 = createFormData("item", "1");
     input2.append("item", "2");
-    const output2 = parse(input2, { schema });
+    const output2 = parseWithValibot(input2, { schema });
     expect(output2).toMatchObject({
       status: "success",
       value: { item: ["1", "2"] },

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, array, string } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
@@ -9,7 +9,7 @@ describe("array", () => {
     const formData = createFormData("select", "1");
     formData.append("select", "2");
     formData.append("select", "3");
-    const output = parse(formData, { schema });
+    const output = parseWithValibot(formData, { schema });
 
     expect(output).toMatchObject({
       status: "success",

--- a/tests/boolean.test.ts
+++ b/tests/boolean.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, boolean } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
@@ -7,12 +7,14 @@ describe("boolean", () => {
   test("should pass only booleans", () => {
     const schema = object({ check: boolean() });
     const input1 = createFormData("check", "on");
-    const output1 = parse(input1, { schema });
+    const output1 = parseWithValibot(input1, { schema });
     expect(output1).toMatchObject({
       status: "success",
       value: { check: true },
     });
-    expect(parse(createFormData("check", ""), { schema })).toMatchObject({
+    expect(
+      parseWithValibot(createFormData("check", ""), { schema }),
+    ).toMatchObject({
       error: { check: ["Invalid type"] },
     });
   });

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -1,19 +1,21 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, date } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
 describe("date", () => {
   test("should pass only dates", () => {
     const schema = object({ birthday: date() });
-    const output = parse(createFormData("birthday", "2023-11-19"), { schema });
+    const output = parseWithValibot(createFormData("birthday", "2023-11-19"), {
+      schema,
+    });
     expect(output).toMatchObject({
       status: "success",
       value: { birthday: new Date("2023-11-19") },
     });
 
     expect(
-      parse(createFormData("birthday", "non date"), { schema }),
+      parseWithValibot(createFormData("birthday", "non date"), { schema }),
     ).toMatchObject({ error: { birthday: ["Invalid type"] } });
   });
 });

--- a/tests/enum.test.ts
+++ b/tests/enum.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, enum_ } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
@@ -13,21 +13,21 @@ describe("enum_", () => {
     const schema = object({ item: enum_(Direction) });
 
     const formData1 = createFormData("item", Direction.Left);
-    const output1 = parse(formData1, { schema });
+    const output1 = parseWithValibot(formData1, { schema });
     expect(output1).toMatchObject({
       status: "success",
       value: { item: Direction.Left },
     });
 
     const formData2 = createFormData("item", Direction.Right);
-    const output2 = parse(formData2, { schema });
+    const output2 = parseWithValibot(formData2, { schema });
     expect(output2).toMatchObject({
       status: "success",
       value: { item: Direction.Right },
     });
 
     const formData3 = createFormData("item", "value_3");
-    const output3 = parse(formData3, { schema });
+    const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
       error: { item: ["Invalid type"] },
     });

--- a/tests/nonNullish.test.ts
+++ b/tests/nonNullish.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import {
   object,
   number,
@@ -16,25 +16,33 @@ describe("nonOptional", () => {
       item: nonNullish(optional(number())),
     });
     const input1 = createFormData("item", "1");
-    const output1 = parse(input1, { schema: schema1 });
+    const output1 = parseWithValibot(input1, { schema: schema1 });
     expect(output1).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
-      parse(createFormData("item", "non Number"), { schema: schema1 }),
+      parseWithValibot(createFormData("item", "non Number"), {
+        schema: schema1,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
     expect(
-      parse(createFormData("item2", "non Param"), { schema: schema1 }),
+      parseWithValibot(createFormData("item2", "non Param"), {
+        schema: schema1,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
 
     const schema2 = object({
       item: nonNullish(union([number(), undefined_()])),
     });
-    const output2 = parse(input1, { schema: schema2 });
+    const output2 = parseWithValibot(input1, { schema: schema2 });
     expect(output2).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
-      parse(createFormData("item", "non Number"), { schema: schema2 }),
+      parseWithValibot(createFormData("item", "non Number"), {
+        schema: schema2,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
     expect(
-      parse(createFormData("item2", "non Param"), { schema: schema2 }),
+      parseWithValibot(createFormData("item2", "non Param"), {
+        schema: schema2,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
   });
 });

--- a/tests/nonOptional.test.ts
+++ b/tests/nonOptional.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import {
   object,
   number,
@@ -16,25 +16,33 @@ describe("nonOptional", () => {
       item: nonOptional(optional(number())),
     });
     const input1 = createFormData("item", "1");
-    const output1 = parse(input1, { schema: schema1 });
+    const output1 = parseWithValibot(input1, { schema: schema1 });
     expect(output1).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
-      parse(createFormData("item", "non Number"), { schema: schema1 }),
+      parseWithValibot(createFormData("item", "non Number"), {
+        schema: schema1,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
     expect(
-      parse(createFormData("item2", "non Param"), { schema: schema1 }),
+      parseWithValibot(createFormData("item2", "non Param"), {
+        schema: schema1,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
 
     const schema2 = object({
       item: nonOptional(union([number(), undefined_()])),
     });
-    const output2 = parse(input1, { schema: schema2 });
+    const output2 = parseWithValibot(input1, { schema: schema2 });
     expect(output2).toMatchObject({ status: "success", value: { item: 1 } });
     expect(
-      parse(createFormData("item", "non Number"), { schema: schema2 }),
+      parseWithValibot(createFormData("item", "non Number"), {
+        schema: schema2,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
     expect(
-      parse(createFormData("item2", "non Param"), { schema: schema2 }),
+      parseWithValibot(createFormData("item2", "non Param"), {
+        schema: schema2,
+      }),
     ).toMatchObject({ error: { item: ["Invalid type"] } });
   });
 });

--- a/tests/nullable.ts
+++ b/tests/nullable.ts
@@ -1,23 +1,25 @@
 import { describe, expect, test } from "vitest";
 import { string, number, object, nullable } from "valibot";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { createFormData } from "./helpers/FormData";
 
 describe("nullable", () => {
   test("should pass also undefined", () => {
     const schema = object({ age: nullable(number()) });
-    const output = parse(createFormData("age", ""), { schema });
+    const output = parseWithValibot(createFormData("age", ""), { schema });
 
     expect(output).toMatchObject({
       status: "success",
       value: { age: undefined },
     });
-    expect(parse(createFormData("age", "20"), { schema })).toMatchObject({
+    expect(
+      parseWithValibot(createFormData("age", "20"), { schema }),
+    ).toMatchObject({
       status: "success",
       value: { age: 20 },
     });
     expect(
-      parse(createFormData("age", "non number"), { schema }),
+      parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({ error: { age: ["Invalid type"] } });
   });
 
@@ -25,14 +27,18 @@ describe("nullable", () => {
     const default_ = "default";
 
     const schema1 = object({ name: nullable(string(), default_) });
-    const output1 = parse(createFormData("name", ""), { schema: schema1 });
+    const output1 = parseWithValibot(createFormData("name", ""), {
+      schema: schema1,
+    });
     expect(output1).toMatchObject({
       status: "success",
       value: { name: "default" },
     });
 
     const schema2 = object({ name: nullable(string(), () => default_) });
-    const output2 = parse(createFormData("name", ""), { schema: schema1 });
+    const output2 = parseWithValibot(createFormData("name", ""), {
+      schema: schema1,
+    });
     expect(output2).toMatchObject({
       status: "success",
       value: { name: "default" },

--- a/tests/nullish.test.ts
+++ b/tests/nullish.test.ts
@@ -1,23 +1,25 @@
 import { describe, expect, test } from "vitest";
 import { string, number, object, nullish } from "valibot";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { createFormData } from "./helpers/FormData";
 
 describe("nullish", () => {
   test("should pass also undefined", () => {
     const schema = object({ age: nullish(number()) });
-    const output = parse(createFormData("age", ""), { schema });
+    const output = parseWithValibot(createFormData("age", ""), { schema });
 
     expect(output).toMatchObject({
       status: "success",
       value: { age: undefined },
     });
-    expect(parse(createFormData("age", "20"), { schema })).toMatchObject({
+    expect(
+      parseWithValibot(createFormData("age", "20"), { schema }),
+    ).toMatchObject({
       status: "success",
       value: { age: 20 },
     });
     expect(
-      parse(createFormData("age", "non number"), { schema }),
+      parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({ error: { age: ["Invalid type"] } });
   });
 
@@ -25,14 +27,18 @@ describe("nullish", () => {
     const default_ = "default";
 
     const schema1 = object({ name: nullish(string(), default_) });
-    const output1 = parse(createFormData("name", ""), { schema: schema1 });
+    const output1 = parseWithValibot(createFormData("name", ""), {
+      schema: schema1,
+    });
     expect(output1).toMatchObject({
       status: "success",
       value: { name: "default" },
     });
 
     const schema2 = object({ name: nullish(string(), () => default_) });
-    const output2 = parse(createFormData("name", ""), { schema: schema1 });
+    const output2 = parseWithValibot(createFormData("name", ""), {
+      schema: schema2,
+    });
     expect(output2).toMatchObject({
       status: "success",
       value: { name: "default" },

--- a/tests/number.test.ts
+++ b/tests/number.test.ts
@@ -1,19 +1,21 @@
 import { number, object } from "valibot";
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { createFormData } from "./helpers/FormData";
 
 describe("number", () => {
   test("should pass only numbers", () => {
     const schema = object({ age: number() });
-    const output = parse(createFormData("age", "20"), { schema });
+    const output = parseWithValibot(createFormData("age", "20"), { schema });
 
     expect(output).toMatchObject({ status: "success", value: { age: 20 } });
-    expect(parse(createFormData("age", ""), { schema })).toMatchObject({
+    expect(
+      parseWithValibot(createFormData("age", ""), { schema }),
+    ).toMatchObject({
       error: { age: ["Invalid type"] },
     });
     expect(
-      parse(createFormData("age", "non number"), { schema }),
+      parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({ error: { age: ["Invalid type"] } });
   });
 });

--- a/tests/optional.test.ts
+++ b/tests/optional.test.ts
@@ -1,23 +1,25 @@
 import { describe, expect, test } from "vitest";
 import { string, number, object, optional } from "valibot";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { createFormData } from "./helpers/FormData";
 
 describe("optional", () => {
   test("should pass also undefined", () => {
     const schema = object({ age: optional(number()) });
-    const output = parse(createFormData("age", ""), { schema });
+    const output = parseWithValibot(createFormData("age", ""), { schema });
 
     expect(output).toMatchObject({
       status: "success",
       value: { age: undefined },
     });
-    expect(parse(createFormData("age", "20"), { schema })).toMatchObject({
+    expect(
+      parseWithValibot(createFormData("age", "20"), { schema }),
+    ).toMatchObject({
       status: "success",
       value: { age: 20 },
     });
     expect(
-      parse(createFormData("age", "non number"), { schema }),
+      parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({ error: { age: ["Invalid type"] } });
   });
 
@@ -25,14 +27,18 @@ describe("optional", () => {
     const default_ = "default";
 
     const schema1 = object({ name: optional(string(), default_) });
-    const output1 = parse(createFormData("name", ""), { schema: schema1 });
+    const output1 = parseWithValibot(createFormData("name", ""), {
+      schema: schema1,
+    });
     expect(output1).toMatchObject({
       status: "success",
       value: { name: "default" },
     });
 
     const schema2 = object({ name: optional(string(), () => default_) });
-    const output2 = parse(createFormData("name", ""), { schema: schema2 });
+    const output2 = parseWithValibot(createFormData("name", ""), {
+      schema: schema2,
+    });
     expect(output2).toMatchObject({
       status: "success",
       value: { name: "default" },

--- a/tests/picklist.test.ts
+++ b/tests/picklist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, picklist } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
@@ -8,21 +8,21 @@ describe("picklist", () => {
     const schema = object({ list: picklist(["value_1", "value_2"]) });
 
     const formData1 = createFormData("list", "value_1");
-    const output1 = parse(formData1, { schema });
+    const output1 = parseWithValibot(formData1, { schema });
     expect(output1).toMatchObject({
       status: "success",
       value: { list: "value_1" },
     });
 
     const formData2 = createFormData("list", "value_2");
-    const output2 = parse(formData2, { schema });
+    const output2 = parseWithValibot(formData2, { schema });
     expect(output2).toMatchObject({
       status: "success",
       value: { list: "value_2" },
     });
 
     const formData3 = createFormData("list", "value_3");
-    const output3 = parse(formData3, { schema });
+    const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
       error: { list: ["Invalid type"] },
     });

--- a/tests/pipe.test.ts
+++ b/tests/pipe.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "vitest";
 import { string, object, optional, nullable } from "valibot";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { createFormData } from "./helpers/FormData";
 
 describe("pipe", () => {
   test("should pass also undefined", () => {
     const schema = object({ name: optional(nullable(string()), null) });
-    const output = parse(createFormData("name", ""), { schema });
+    const output = parseWithValibot(createFormData("name", ""), { schema });
     expect(output).toMatchObject({ status: "success", value: { name: null } });
   });
 });

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -1,19 +1,21 @@
 import { object, string } from "valibot";
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { createFormData } from "./helpers/FormData";
 
 describe("string", () => {
   test("should pass only strings", () => {
     const schema = object({ name: string() });
 
-    const output = parse(createFormData("name", "Jane"), { schema });
+    const output = parseWithValibot(createFormData("name", "Jane"), { schema });
 
     expect(output).toMatchObject({
       status: "success",
       value: { name: "Jane" },
     });
-    expect(parse(createFormData("name", ""), { schema })).toMatchObject({
+    expect(
+      parseWithValibot(createFormData("name", ""), { schema }),
+    ).toMatchObject({
       error: { name: ["Invalid type"] },
     });
   });

--- a/tests/undefined.test.ts
+++ b/tests/undefined.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, undefined_, string } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
@@ -7,20 +7,20 @@ describe("undefined", () => {
   test("should pass only undefined", () => {
     const schema = object({ name: string(), age: undefined_() });
     const formData1 = createFormData("name", "Jane");
-    expect(parse(formData1, { schema })).toMatchObject({
+    expect(parseWithValibot(formData1, { schema })).toMatchObject({
       status: "success",
       value: { name: "Jane" },
     });
 
     formData1.append("age", "");
-    expect(parse(formData1, { schema })).toMatchObject({
+    expect(parseWithValibot(formData1, { schema })).toMatchObject({
       status: "success",
       value: { name: "Jane", age: undefined },
     });
 
     const formData2 = createFormData("name", "Jane");
     formData2.append("age", "20");
-    expect(parse(formData2, { schema })).toMatchObject({
+    expect(parseWithValibot(formData2, { schema })).toMatchObject({
       error: { age: ["Invalid type"] },
     });
   });

--- a/tests/union.test.ts
+++ b/tests/union.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, test } from "vitest";
-import { parse } from "../parse";
+import { parseWithValibot } from "../parse";
 import { object, union, number, undefined_ } from "valibot";
 import { createFormData } from "./helpers/FormData";
 
 describe("union", () => {
   test("should pass only union values", () => {
     const schema = object({ age: union([number(), undefined_()]) });
-    const output1 = parse(createFormData("age", "30"), { schema });
+    const output1 = parseWithValibot(createFormData("age", "30"), { schema });
     expect(output1).toMatchObject({ status: "success", value: { age: 30 } });
 
-    const output2 = parse(createFormData("age", ""), { schema });
+    const output2 = parseWithValibot(createFormData("age", ""), { schema });
     expect(output2).toMatchObject({
       status: "success",
       value: { age: undefined },
     });
 
     expect(
-      parse(createFormData("age", "non number"), { schema }),
+      parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
       error: { age: ["Invalid type"] },
     });


### PR DESCRIPTION
## Overview

Change the name of the parse function in accordance with version 1 of conform.

https://github.com/edmundhung/conform/commit/732b09f2a1d43e13df1cc3962f81943869fba01a