### PR TITLE
Add `lang` property in ParseInfo supported props

### DIFF
--- a/constraint.ts
+++ b/constraint.ts
@@ -1,5 +1,5 @@
 import type { Constraint } from "@conform-to/dom";
-import type { WrapSchema, AllSchema, ObjectSchema } from "./types/schema";
+import type { AllSchema } from "./types/schema";
 
 const keys: Array<keyof Constraint> = [
   "required",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "semantic-release": "^22.0.8",
         "tsup": "^8.0.0",
         "typescript": "^5.2.2",
-        "valibot": "^0.27.0",
+        "valibot": "^0.28.0",
         "vitest": "^0.34.6"
       },
       "peerDependencies": {
         "@conform-to/dom": "^1.0.0",
-        "valibot": "^0.27.0"
+        "valibot": "^0.28.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7839,9 +7839,9 @@
       "dev": true
     },
     "node_modules/valibot": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.27.1.tgz",
-      "integrity": "sha512-k57/5/kMwMjiVP0LUMpa+n4ihSemuXshz1ND4fftKw1bkHZYN/TnHcbjaEie3K7FwAceiOgugLZPjSaNxdygeg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.28.1.tgz",
+      "integrity": "sha512-zQnjwNJuXk6362Leu0+4eFa/SMwRom3/hEvH6s1EGf3oXIPbo2WFKDra9ymnbVh3clLRvd8hw4sKF5ruI2Lyvw==",
       "dev": true
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "peerDependencies": {
     "@conform-to/dom": "^1.0.0",
-    "valibot": "^0.27.0"
+    "valibot": "^0.28.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.3.3",
@@ -43,7 +43,7 @@
     "semantic-release": "^22.0.8",
     "tsup": "^8.0.0",
     "typescript": "^5.2.2",
-    "valibot": "^0.27.0",
+    "valibot": "^0.28.0",
     "vitest": "^0.34.6"
   }
 }

--- a/parse.ts
+++ b/parse.ts
@@ -17,21 +17,30 @@ export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
-    info?: Pick<SchemaConfig, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
+    info?: Pick<
+      SchemaConfig,
+      "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang"
+    >;
   },
 ): Submission<Output<Schema>>;
 export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
-    info?: Pick<SchemaConfig, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
+    info?: Pick<
+      SchemaConfig,
+      "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang"
+    >;
   },
 ): Promise<Submission<Output<Schema>>>;
 export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: Intent | null) => Schema);
-    info?: Pick<SchemaConfig, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
+    info?: Pick<
+      SchemaConfig,
+      "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang"
+    >;
   },
 ): Submission<Output<Schema>> | Promise<Submission<Output<Schema>>> {
   return baseParse<Output<Schema>, string[]>(payload, {

--- a/parse.ts
+++ b/parse.ts
@@ -17,21 +17,21 @@ export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
-    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe">;
+    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
   },
 ): Submission<Output<Schema>>;
 export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
-    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe">;
+    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
   },
 ): Promise<Submission<Output<Schema>>>;
 export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: Intent | null) => Schema);
-    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe">;
+    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
   },
 ): Submission<Output<Schema>> | Promise<Submission<Output<Schema>>> {
   return baseParse<Output<Schema>, string[]>(payload, {

--- a/parse.ts
+++ b/parse.ts
@@ -7,7 +7,7 @@ import {
 import {
   type BaseSchema,
   type Output,
-  type ParseInfo,
+  type SchemaConfig,
   SafeParseResult,
   safeParse,
 } from "valibot";
@@ -17,21 +17,21 @@ export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
-    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
+    info?: Pick<SchemaConfig, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
   },
 ): Submission<Output<Schema>>;
 export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: string) => Schema);
-    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
+    info?: Pick<SchemaConfig, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
   },
 ): Promise<Submission<Output<Schema>>>;
 export function parseWithValibot<Schema extends BaseSchema & { type: string }>(
   payload: FormData | URLSearchParams,
   config: {
     schema: Schema | ((intent: Intent | null) => Schema);
-    info?: Pick<ParseInfo, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
+    info?: Pick<SchemaConfig, "abortEarly" | "abortPipeEarly" | "skipPipe" | "lang">;
   },
 ): Submission<Output<Schema>> | Promise<Submission<Output<Schema>>> {
   return baseParse<Output<Schema>, string[]>(payload, {

--- a/tests/coercion/schema/array.test.ts
+++ b/tests/coercion/schema/array.test.ts
@@ -27,7 +27,7 @@ describe("array", () => {
     const errorFormData = createFormData("nest[].name", "");
     const errorOutput = parseWithValibot(errorFormData, { schema: schema2 });
     expect(errorOutput).toMatchObject({
-      error: { "nest[0].name": ["Invalid type"] },
+      error: { "nest[0].name": ["Invalid type: Expected string but received undefined"] },
     });
   });
 });

--- a/tests/coercion/schema/array.test.ts
+++ b/tests/coercion/schema/array.test.ts
@@ -27,7 +27,11 @@ describe("array", () => {
     const errorFormData = createFormData("nest[].name", "");
     const errorOutput = parseWithValibot(errorFormData, { schema: schema2 });
     expect(errorOutput).toMatchObject({
-      error: { "nest[0].name": ["Invalid type: Expected string but received undefined"] },
+      error: {
+        "nest[0].name": [
+          "Invalid type: Expected string but received undefined",
+        ],
+      },
     });
   });
 });

--- a/tests/coercion/schema/bigint.test.ts
+++ b/tests/coercion/schema/bigint.test.ts
@@ -16,6 +16,8 @@ describe("bigint", () => {
     });
     expect(
       parseWithValibot(createFormData("id", "non bigint"), { schema }),
-    ).toMatchObject({ error: { id: ["Invalid type: Expected bigint but received undefined"] } });
+    ).toMatchObject({
+      error: { id: ["Invalid type: Expected bigint but received undefined"] },
+    });
   });
 });

--- a/tests/coercion/schema/bigint.test.ts
+++ b/tests/coercion/schema/bigint.test.ts
@@ -12,10 +12,10 @@ describe("bigint", () => {
     expect(
       parseWithValibot(createFormData("id", ""), { schema }),
     ).toMatchObject({
-      error: { id: ["Invalid type"] },
+      error: { id: ["Invalid type: Expected bigint but received undefined"] },
     });
     expect(
       parseWithValibot(createFormData("id", "non bigint"), { schema }),
-    ).toMatchObject({ error: { id: ["Invalid type"] } });
+    ).toMatchObject({ error: { id: ["Invalid type: Expected bigint but received undefined"] } });
   });
 });

--- a/tests/coercion/schema/boolean.test.ts
+++ b/tests/coercion/schema/boolean.test.ts
@@ -15,7 +15,7 @@ describe("boolean", () => {
     expect(
       parseWithValibot(createFormData("check", ""), { schema }),
     ).toMatchObject({
-      error: { check: ["Invalid type"] },
+      error: { check: ["Invalid type: Expected boolean but received undefined"] },
     });
   });
 });

--- a/tests/coercion/schema/boolean.test.ts
+++ b/tests/coercion/schema/boolean.test.ts
@@ -15,7 +15,9 @@ describe("boolean", () => {
     expect(
       parseWithValibot(createFormData("check", ""), { schema }),
     ).toMatchObject({
-      error: { check: ["Invalid type: Expected boolean but received undefined"] },
+      error: {
+        check: ["Invalid type: Expected boolean but received undefined"],
+      },
     });
   });
 });

--- a/tests/coercion/schema/date.test.ts
+++ b/tests/coercion/schema/date.test.ts
@@ -16,6 +16,10 @@ describe("date", () => {
 
     expect(
       parseWithValibot(createFormData("birthday", "non date"), { schema }),
-    ).toMatchObject({ error: { birthday: ["Invalid type: Expected Date but received \"non date\""] } });
+    ).toMatchObject({
+      error: {
+        birthday: ['Invalid type: Expected Date but received "non date"'],
+      },
+    });
   });
 });

--- a/tests/coercion/schema/date.test.ts
+++ b/tests/coercion/schema/date.test.ts
@@ -16,6 +16,6 @@ describe("date", () => {
 
     expect(
       parseWithValibot(createFormData("birthday", "non date"), { schema }),
-    ).toMatchObject({ error: { birthday: ["Invalid type"] } });
+    ).toMatchObject({ error: { birthday: ["Invalid type: Expected Date but received \"non date\""] } });
   });
 });

--- a/tests/coercion/schema/enum.test.ts
+++ b/tests/coercion/schema/enum.test.ts
@@ -29,7 +29,7 @@ describe("enum_", () => {
     const formData3 = createFormData("item", "value_3");
     const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
-      error: { item: ["Invalid type"] },
+      error: { item: ["Invalid type: Expected \"left\" | \"right\" but received \"value_3\""] },
     });
   });
 });

--- a/tests/coercion/schema/enum.test.ts
+++ b/tests/coercion/schema/enum.test.ts
@@ -29,7 +29,11 @@ describe("enum_", () => {
     const formData3 = createFormData("item", "value_3");
     const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
-      error: { item: ["Invalid type: Expected \"left\" | \"right\" but received \"value_3\""] },
+      error: {
+        item: [
+          'Invalid type: Expected "left" | "right" but received "value_3"',
+        ],
+      },
     });
   });
 });

--- a/tests/coercion/schema/intersect.test.ts
+++ b/tests/coercion/schema/intersect.test.ts
@@ -18,12 +18,19 @@ describe("intersect", () => {
     const errorInput1 = createFormData("intersect", "foo");
     const errorOutput1 = parseWithValibot(errorInput1, { schema: schema1 });
     expect(errorOutput1).toMatchObject({
-      error: { intersect: ["Invalid type: Expected \"test\" but received \"foo\""] },
+      error: {
+        intersect: ['Invalid type: Expected "test" but received "foo"'],
+      },
     });
     const errorInput2 = createFormData("intersect", "");
     const errorOutput2 = parseWithValibot(errorInput2, { schema: schema1 });
     expect(errorOutput2).toMatchObject({
-      error: { intersect: ["Invalid type: Expected string but received undefined", "Invalid type: Expected \"test\" but received undefined"] },
+      error: {
+        intersect: [
+          "Invalid type: Expected string but received undefined",
+          'Invalid type: Expected "test" but received undefined',
+        ],
+      },
     });
 
     const schema2 = intersect([
@@ -57,7 +64,9 @@ describe("intersect", () => {
     const info = { abortEarly: true };
     const errorOutput = parseWithValibot(errorInput, { schema, info });
     expect(errorOutput).toMatchObject({
-      error: { intersect: ["Invalid type: Expected string but received undefined"] },
+      error: {
+        intersect: ["Invalid type: Expected string but received undefined"],
+      },
     });
   });
 });

--- a/tests/coercion/schema/intersect.test.ts
+++ b/tests/coercion/schema/intersect.test.ts
@@ -18,12 +18,12 @@ describe("intersect", () => {
     const errorInput1 = createFormData("intersect", "foo");
     const errorOutput1 = parseWithValibot(errorInput1, { schema: schema1 });
     expect(errorOutput1).toMatchObject({
-      error: { intersect: ["Invalid type"] },
+      error: { intersect: ["Invalid type: Expected \"test\" but received \"foo\""] },
     });
     const errorInput2 = createFormData("intersect", "");
     const errorOutput2 = parseWithValibot(errorInput2, { schema: schema1 });
     expect(errorOutput2).toMatchObject({
-      error: { intersect: ["Invalid type", "Invalid type"] },
+      error: { intersect: ["Invalid type: Expected string but received undefined", "Invalid type: Expected \"test\" but received undefined"] },
     });
 
     const schema2 = intersect([
@@ -40,12 +40,12 @@ describe("intersect", () => {
     const errorInput3 = createFormData("foo", "test");
     const errorOutput3 = parseWithValibot(errorInput3, { schema: schema2 });
     expect(errorOutput3).toMatchObject({
-      error: { bar: ["Invalid type"] },
+      error: { bar: ["Invalid type: Expected string but received undefined"] },
     });
     const errorInput4 = createFormData("bar", "test");
     const errorOutput4 = parseWithValibot(errorInput4, { schema: schema2 });
     expect(errorOutput4).toMatchObject({
-      error: { foo: ["Invalid type"] },
+      error: { foo: ["Invalid type: Expected string but received undefined"] },
     });
   });
 
@@ -57,7 +57,7 @@ describe("intersect", () => {
     const info = { abortEarly: true };
     const errorOutput = parseWithValibot(errorInput, { schema, info });
     expect(errorOutput).toMatchObject({
-      error: { intersect: ["Invalid type"] },
+      error: { intersect: ["Invalid type: Expected string but received undefined"] },
     });
   });
 });

--- a/tests/coercion/schema/nonNullish.test.ts
+++ b/tests/coercion/schema/nonNullish.test.ts
@@ -22,12 +22,20 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected number but received NaN"] } });
+    ).toMatchObject({
+      error: { item: ["Invalid type: Expected number but received NaN"] },
+    });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected !null & !undefined but received undefined"] } });
+    ).toMatchObject({
+      error: {
+        item: [
+          "Invalid type: Expected !null & !undefined but received undefined",
+        ],
+      },
+    });
 
     const schema2 = object({
       item: nonNullish(union([number(), undefined_()])),
@@ -38,11 +46,23 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected number | undefined but received \"non Number\""] } });
+    ).toMatchObject({
+      error: {
+        item: [
+          'Invalid type: Expected number | undefined but received "non Number"',
+        ],
+      },
+    });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected !null & !undefined but received undefined"] } });
+    ).toMatchObject({
+      error: {
+        item: [
+          "Invalid type: Expected !null & !undefined but received undefined",
+        ],
+      },
+    });
   });
 });

--- a/tests/coercion/schema/nonNullish.test.ts
+++ b/tests/coercion/schema/nonNullish.test.ts
@@ -22,12 +22,12 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected number but received NaN"] } });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected !null & !undefined but received undefined"] } });
 
     const schema2 = object({
       item: nonNullish(union([number(), undefined_()])),
@@ -38,11 +38,11 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected number | undefined but received \"non Number\""] } });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected !null & !undefined but received undefined"] } });
   });
 });

--- a/tests/coercion/schema/nonOptional.test.ts
+++ b/tests/coercion/schema/nonOptional.test.ts
@@ -22,12 +22,18 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected number but received NaN"] } });
+    ).toMatchObject({
+      error: { item: ["Invalid type: Expected number but received NaN"] },
+    });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected !undefined but received undefined"] } });
+    ).toMatchObject({
+      error: {
+        item: ["Invalid type: Expected !undefined but received undefined"],
+      },
+    });
 
     const schema2 = object({
       item: nonOptional(union([number(), undefined_()])),
@@ -38,11 +44,21 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected number | undefined but received \"non Number\""] } });
+    ).toMatchObject({
+      error: {
+        item: [
+          'Invalid type: Expected number | undefined but received "non Number"',
+        ],
+      },
+    });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type: Expected !undefined but received undefined"] } });
+    ).toMatchObject({
+      error: {
+        item: ["Invalid type: Expected !undefined but received undefined"],
+      },
+    });
   });
 });

--- a/tests/coercion/schema/nonOptional.test.ts
+++ b/tests/coercion/schema/nonOptional.test.ts
@@ -22,12 +22,12 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected number but received NaN"] } });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema1,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected !undefined but received undefined"] } });
 
     const schema2 = object({
       item: nonOptional(union([number(), undefined_()])),
@@ -38,11 +38,11 @@ describe("nonOptional", () => {
       parseWithValibot(createFormData("item", "non Number"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected number | undefined but received \"non Number\""] } });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
         schema: schema2,
       }),
-    ).toMatchObject({ error: { item: ["Invalid type"] } });
+    ).toMatchObject({ error: { item: ["Invalid type: Expected !undefined but received undefined"] } });
   });
 });

--- a/tests/coercion/schema/nullish.test.ts
+++ b/tests/coercion/schema/nullish.test.ts
@@ -20,7 +20,7 @@ describe("nullish", () => {
     });
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
-    ).toMatchObject({ error: { age: ["Invalid type"] } });
+    ).toMatchObject({ error: { age: ["Invalid type: Expected number but received NaN"] } });
   });
 
   test("should use default if required", () => {

--- a/tests/coercion/schema/nullish.test.ts
+++ b/tests/coercion/schema/nullish.test.ts
@@ -20,7 +20,9 @@ describe("nullish", () => {
     });
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
-    ).toMatchObject({ error: { age: ["Invalid type: Expected number but received NaN"] } });
+    ).toMatchObject({
+      error: { age: ["Invalid type: Expected number but received NaN"] },
+    });
   });
 
   test("should use default if required", () => {

--- a/tests/coercion/schema/number.test.ts
+++ b/tests/coercion/schema/number.test.ts
@@ -12,10 +12,10 @@ describe("number", () => {
     expect(
       parseWithValibot(createFormData("age", ""), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type"] },
+      error: { age: ["Invalid type: Expected number but received undefined"] },
     });
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
-    ).toMatchObject({ error: { age: ["Invalid type"] } });
+    ).toMatchObject({ error: { age: ["Invalid type: Expected number but received NaN"] } });
   });
 });

--- a/tests/coercion/schema/number.test.ts
+++ b/tests/coercion/schema/number.test.ts
@@ -16,6 +16,8 @@ describe("number", () => {
     });
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
-    ).toMatchObject({ error: { age: ["Invalid type: Expected number but received NaN"] } });
+    ).toMatchObject({
+      error: { age: ["Invalid type: Expected number but received NaN"] },
+    });
   });
 });

--- a/tests/coercion/schema/optional.test.ts
+++ b/tests/coercion/schema/optional.test.ts
@@ -20,7 +20,9 @@ describe("optional", () => {
     });
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
-    ).toMatchObject({ error: { age: ["Invalid type: Expected number but received NaN"] } });
+    ).toMatchObject({
+      error: { age: ["Invalid type: Expected number but received NaN"] },
+    });
   });
 
   test("should use default if required", () => {

--- a/tests/coercion/schema/optional.test.ts
+++ b/tests/coercion/schema/optional.test.ts
@@ -20,7 +20,7 @@ describe("optional", () => {
     });
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
-    ).toMatchObject({ error: { age: ["Invalid type"] } });
+    ).toMatchObject({ error: { age: ["Invalid type: Expected number but received NaN"] } });
   });
 
   test("should use default if required", () => {

--- a/tests/coercion/schema/picklist.test.ts
+++ b/tests/coercion/schema/picklist.test.ts
@@ -24,7 +24,11 @@ describe("picklist", () => {
     const formData3 = createFormData("list", "value_3");
     const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
-      error: { list: ["Invalid type: Expected \"value_1\" | \"value_2\" but received \"value_3\""] },
+      error: {
+        list: [
+          'Invalid type: Expected "value_1" | "value_2" but received "value_3"',
+        ],
+      },
     });
   });
 });

--- a/tests/coercion/schema/picklist.test.ts
+++ b/tests/coercion/schema/picklist.test.ts
@@ -24,7 +24,7 @@ describe("picklist", () => {
     const formData3 = createFormData("list", "value_3");
     const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
-      error: { list: ["Invalid type"] },
+      error: { list: ["Invalid type: Expected \"value_1\" | \"value_2\" but received \"value_3\""] },
     });
   });
 });

--- a/tests/coercion/schema/string.test.ts
+++ b/tests/coercion/schema/string.test.ts
@@ -16,7 +16,7 @@ describe("string", () => {
     expect(
       parseWithValibot(createFormData("name", ""), { schema }),
     ).toMatchObject({
-      error: { name: ["Invalid type"] },
+      error: { name: ["Invalid type: Expected string but received undefined"] },
     });
   });
 });

--- a/tests/coercion/schema/tuple.test.ts
+++ b/tests/coercion/schema/tuple.test.ts
@@ -25,11 +25,11 @@ describe("tuple", () => {
 
     const errorInput1 = createFormData("tuple", "1");
     expect(parseWithValibot(errorInput1, { schema: schema1 })).toMatchObject({
-      error: { tuple: ["Invalid type: Expected Array but received \"1\""] },
+      error: { tuple: ['Invalid type: Expected Array but received "1"'] },
     });
     const errorInput2 = createFormData("tuple", "123");
     expect(parseWithValibot(errorInput2, { schema: schema1 })).toMatchObject({
-      error: { tuple: ["Invalid type: Expected Array but received \"123\""] },
+      error: { tuple: ['Invalid type: Expected Array but received "123"'] },
     });
 
     const schema2 = object({ tuple: tuple([string()], optional(number())) });

--- a/tests/coercion/schema/tuple.test.ts
+++ b/tests/coercion/schema/tuple.test.ts
@@ -25,11 +25,11 @@ describe("tuple", () => {
 
     const errorInput1 = createFormData("tuple", "1");
     expect(parseWithValibot(errorInput1, { schema: schema1 })).toMatchObject({
-      error: { tuple: ["Invalid type"] },
+      error: { tuple: ["Invalid type: Expected Array but received \"1\""] },
     });
     const errorInput2 = createFormData("tuple", "123");
     expect(parseWithValibot(errorInput2, { schema: schema1 })).toMatchObject({
-      error: { tuple: ["Invalid type"] },
+      error: { tuple: ["Invalid type: Expected Array but received \"123\""] },
     });
 
     const schema2 = object({ tuple: tuple([string()], optional(number())) });

--- a/tests/coercion/schema/undefined.test.ts
+++ b/tests/coercion/schema/undefined.test.ts
@@ -21,7 +21,7 @@ describe("undefined", () => {
     const formData2 = createFormData("name", "Jane");
     formData2.append("age", "20");
     expect(parseWithValibot(formData2, { schema })).toMatchObject({
-      error: { age: ["Invalid type"] },
+      error: { age: ["Invalid type: Expected undefined but received \"20\""] },
     });
   });
 });

--- a/tests/coercion/schema/undefined.test.ts
+++ b/tests/coercion/schema/undefined.test.ts
@@ -21,7 +21,7 @@ describe("undefined", () => {
     const formData2 = createFormData("name", "Jane");
     formData2.append("age", "20");
     expect(parseWithValibot(formData2, { schema })).toMatchObject({
-      error: { age: ["Invalid type: Expected undefined but received \"20\""] },
+      error: { age: ['Invalid type: Expected undefined but received "20"'] },
     });
   });
 });

--- a/tests/coercion/schema/union.test.ts
+++ b/tests/coercion/schema/union.test.ts
@@ -18,7 +18,7 @@ describe("union", () => {
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type"] },
+      error: { age: ["Invalid type: Expected number | undefined but received \"non number\""] },
     });
   });
 });

--- a/tests/coercion/schema/union.test.ts
+++ b/tests/coercion/schema/union.test.ts
@@ -18,7 +18,11 @@ describe("union", () => {
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number | undefined but received \"non number\""] },
+      error: {
+        age: [
+          'Invalid type: Expected number | undefined but received "non number"',
+        ],
+      },
     });
   });
 });

--- a/tests/coercion/schema/variant.test.ts
+++ b/tests/coercion/schema/variant.test.ts
@@ -53,11 +53,11 @@ describe("variant", () => {
 
     const errorInput1 = createFormData("type", "x");
     expect(parseWithValibot(errorInput1, { schema: schema2 })).toMatchObject({
-      error: { type: ["Invalid type"] },
+      error: { type: ["Invalid type: Expected \"a\" | \"b\" but received \"x\""] },
     });
     const errorInput2 = createFormData("type2", "a");
     expect(parseWithValibot(errorInput2, { schema: schema2 })).toMatchObject({
-      error: { type: ["Invalid type"] },
+      error: { type: ["Invalid type: Expected \"a\" | \"b\" but received undefined"] },
     });
   });
 });

--- a/tests/coercion/schema/variant.test.ts
+++ b/tests/coercion/schema/variant.test.ts
@@ -53,11 +53,13 @@ describe("variant", () => {
 
     const errorInput1 = createFormData("type", "x");
     expect(parseWithValibot(errorInput1, { schema: schema2 })).toMatchObject({
-      error: { type: ["Invalid type: Expected \"a\" | \"b\" but received \"x\""] },
+      error: { type: ['Invalid type: Expected "a" | "b" but received "x"'] },
     });
     const errorInput2 = createFormData("type2", "a");
     expect(parseWithValibot(errorInput2, { schema: schema2 })).toMatchObject({
-      error: { type: ["Invalid type: Expected \"a\" | \"b\" but received undefined"] },
+      error: {
+        type: ['Invalid type: Expected "a" | "b" but received undefined'],
+      },
     });
   });
 });


### PR DESCRIPTION
This PR allows the user to pass the `lang` param to valibot, used for `i18n`.

```ts
const submission = await parseWithValibot(formData, {
    schema,
    info: { lang: await i18nServer.getLocale(request) },
});
```