### PR TITLE
Fix the judgment of validation error in test code

### DIFF
--- a/tests/coercion/schema/array.test.ts
+++ b/tests/coercion/schema/array.test.ts
@@ -28,9 +28,7 @@ describe("array", () => {
     const errorOutput = parseWithValibot(errorFormData, { schema: schema2 });
     expect(errorOutput).toMatchObject({
       error: {
-        "nest[0].name": [
-          "Invalid type: Expected string but received undefined",
-        ],
+        "nest[0].name": expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/bigint.test.ts
+++ b/tests/coercion/schema/bigint.test.ts
@@ -12,12 +12,12 @@ describe("bigint", () => {
     expect(
       parseWithValibot(createFormData("id", ""), { schema }),
     ).toMatchObject({
-      error: { id: ["Invalid type: Expected bigint but received undefined"] },
+      error: { id: expect.anything() },
     });
     expect(
       parseWithValibot(createFormData("id", "non bigint"), { schema }),
     ).toMatchObject({
-      error: { id: ["Invalid type: Expected bigint but received undefined"] },
+      error: { id: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/blob.test.ts
+++ b/tests/coercion/schema/blob.test.ts
@@ -17,7 +17,7 @@ describe("blob", () => {
     expect(
       parseWithValibot(createFormData("name", ""), { schema }),
     ).toMatchObject({
-      error: { file: ["Invalid type: Expected Blob but received undefined"] },
+      error: { file: expect.anything() },
     });
   });
 
@@ -41,9 +41,7 @@ describe("blob", () => {
       ),
     ).toMatchObject({
       error: {
-        file: [
-          'Invalid MIME type: Expected "image/jpeg" | "image/png" but received "image/gif"',
-        ],
+        file: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/boolean.test.ts
+++ b/tests/coercion/schema/boolean.test.ts
@@ -16,7 +16,7 @@ describe("boolean", () => {
       parseWithValibot(createFormData("check", ""), { schema }),
     ).toMatchObject({
       error: {
-        check: ["Invalid type: Expected boolean but received undefined"],
+        check: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/date.test.ts
+++ b/tests/coercion/schema/date.test.ts
@@ -18,7 +18,7 @@ describe("date", () => {
       parseWithValibot(createFormData("birthday", "non date"), { schema }),
     ).toMatchObject({
       error: {
-        birthday: ['Invalid type: Expected Date but received "non date"'],
+        birthday: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/enum.test.ts
+++ b/tests/coercion/schema/enum.test.ts
@@ -30,9 +30,7 @@ describe("enum_", () => {
     const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
       error: {
-        item: [
-          'Invalid type: Expected "left" | "right" but received "value_3"',
-        ],
+        item: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/file.test.ts
+++ b/tests/coercion/schema/file.test.ts
@@ -20,7 +20,7 @@ describe("file", () => {
     expect(
       parseWithValibot(createFormData("name", ""), { schema }),
     ).toMatchObject({
-      error: { file: ["Invalid type: Expected File but received undefined"] },
+      error: { file: expect.anything() },
     });
   });
 
@@ -50,9 +50,7 @@ describe("file", () => {
       ),
     ).toMatchObject({
       error: {
-        file: [
-          'Invalid MIME type: Expected "image/jpeg" | "image/png" but received "image/gif"',
-        ],
+        file: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/intersect.test.ts
+++ b/tests/coercion/schema/intersect.test.ts
@@ -19,17 +19,14 @@ describe("intersect", () => {
     const errorOutput1 = parseWithValibot(errorInput1, { schema: schema1 });
     expect(errorOutput1).toMatchObject({
       error: {
-        intersect: ['Invalid type: Expected "test" but received "foo"'],
+        intersect: expect.anything(),
       },
     });
     const errorInput2 = createFormData("intersect", "");
     const errorOutput2 = parseWithValibot(errorInput2, { schema: schema1 });
     expect(errorOutput2).toMatchObject({
       error: {
-        intersect: [
-          "Invalid type: Expected string but received undefined",
-          'Invalid type: Expected "test" but received undefined',
-        ],
+        intersect: expect.anything(),
       },
     });
 
@@ -47,12 +44,12 @@ describe("intersect", () => {
     const errorInput3 = createFormData("foo", "test");
     const errorOutput3 = parseWithValibot(errorInput3, { schema: schema2 });
     expect(errorOutput3).toMatchObject({
-      error: { bar: ["Invalid type: Expected string but received undefined"] },
+      error: { bar: expect.anything() },
     });
     const errorInput4 = createFormData("bar", "test");
     const errorOutput4 = parseWithValibot(errorInput4, { schema: schema2 });
     expect(errorOutput4).toMatchObject({
-      error: { foo: ["Invalid type: Expected string but received undefined"] },
+      error: { foo: expect.anything() },
     });
   });
 
@@ -74,7 +71,7 @@ describe("intersect", () => {
     const errorOutput1 = parseWithValibot(errorInput1, { schema });
     expect(errorOutput1).toMatchObject({
       error: {
-        intersect: ["intersect must be equal to test"],
+        intersect: expect.anything(),
       },
     });
   });
@@ -88,7 +85,7 @@ describe("intersect", () => {
     const errorOutput = parseWithValibot(errorInput, { schema, info });
     expect(errorOutput).toMatchObject({
       error: {
-        intersect: ["Invalid type: Expected string but received undefined"],
+        intersect: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/intersectAsync.test.ts
+++ b/tests/coercion/schema/intersectAsync.test.ts
@@ -28,7 +28,7 @@ describe("intersectAsync", () => {
     });
     expect(errorOutput1).toMatchObject({
       error: {
-        intersect: ['Invalid type: Expected "test" but received "foo"'],
+        intersect: expect.anything(),
       },
     });
     const errorInput2 = createFormData("intersect", "");
@@ -37,10 +37,7 @@ describe("intersectAsync", () => {
     });
     expect(errorOutput2).toMatchObject({
       error: {
-        intersect: [
-          "Invalid type: Expected string but received undefined",
-          'Invalid type: Expected "test" but received undefined',
-        ],
+        intersect: expect.anything(),
       },
     });
 
@@ -60,14 +57,14 @@ describe("intersectAsync", () => {
       schema: schema2,
     });
     expect(errorOutput3).toMatchObject({
-      error: { bar: ["Invalid type: Expected string but received undefined"] },
+      error: { bar: expect.anything() },
     });
     const errorInput4 = createFormData("bar", "test");
     const errorOutput4 = await parseWithValibot(errorInput4, {
       schema: schema2,
     });
     expect(errorOutput4).toMatchObject({
-      error: { foo: ["Invalid type: Expected string but received undefined"] },
+      error: { foo: expect.anything() },
     });
   });
 
@@ -92,7 +89,7 @@ describe("intersectAsync", () => {
     const errorOutput1 = await parseWithValibot(errorInput1, { schema });
     expect(errorOutput1).toMatchObject({
       error: {
-        intersect: ["intersect must be equal to test"],
+        intersect: expect.anything(),
       },
     });
   });
@@ -106,7 +103,7 @@ describe("intersectAsync", () => {
     const errorOutput = await parseWithValibot(errorInput, { schema, info });
     expect(errorOutput).toMatchObject({
       error: {
-        intersect: ["Invalid type: Expected string but received undefined"],
+        intersect: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/nonNullish.test.ts
+++ b/tests/coercion/schema/nonNullish.test.ts
@@ -25,7 +25,7 @@ describe("nonOptional", () => {
         schema: schema1,
       }),
     ).toMatchObject({
-      error: { item: ["Invalid type: Expected number but received NaN"] },
+      error: { item: expect.anything() },
     });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
@@ -33,9 +33,7 @@ describe("nonOptional", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          "Invalid type: Expected !null & !undefined but received undefined",
-        ],
+        item: expect.anything(),
       },
     });
 
@@ -50,9 +48,7 @@ describe("nonOptional", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          'Invalid type: Expected number | undefined but received "non Number"',
-        ],
+        item: expect.anything(),
       },
     });
     expect(
@@ -61,9 +57,7 @@ describe("nonOptional", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          "Invalid type: Expected !null & !undefined but received undefined",
-        ],
+        item: expect.anything(),
       },
     });
   });
@@ -79,9 +73,7 @@ describe("nonOptional", () => {
     const output1 = parseWithValibot(createFormData("age", ""), { schema });
     expect(output1).toMatchObject({
       error: {
-        age: [
-          "Invalid type: Expected !null & !undefined but received undefined",
-        ],
+        age: expect.anything(),
       },
     });
 
@@ -95,7 +87,7 @@ describe("nonOptional", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/nonNullishAsync.test.ts
+++ b/tests/coercion/schema/nonNullishAsync.test.ts
@@ -25,7 +25,7 @@ describe("nonOptionalAsync", () => {
         schema: schema1,
       }),
     ).toMatchObject({
-      error: { item: ["Invalid type: Expected number but received NaN"] },
+      error: { item: expect.anything() },
     });
     expect(
       await parseWithValibot(createFormData("item2", "non Param"), {
@@ -33,9 +33,7 @@ describe("nonOptionalAsync", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          "Invalid type: Expected !null & !undefined but received undefined",
-        ],
+        item: expect.anything(),
       },
     });
 
@@ -50,9 +48,7 @@ describe("nonOptionalAsync", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          'Invalid type: Expected number | undefined but received "non Number"',
-        ],
+        item: expect.anything(),
       },
     });
     expect(
@@ -61,9 +57,7 @@ describe("nonOptionalAsync", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          "Invalid type: Expected !null & !undefined but received undefined",
-        ],
+        item: expect.anything(),
       },
     });
   });
@@ -81,9 +75,7 @@ describe("nonOptionalAsync", () => {
     });
     expect(output1).toMatchObject({
       error: {
-        age: [
-          "Invalid type: Expected !null & !undefined but received undefined",
-        ],
+        age: expect.anything(),
       },
     });
 
@@ -99,7 +91,7 @@ describe("nonOptionalAsync", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/nonOptional.test.ts
+++ b/tests/coercion/schema/nonOptional.test.ts
@@ -25,7 +25,7 @@ describe("nonOptional", () => {
         schema: schema1,
       }),
     ).toMatchObject({
-      error: { item: ["Invalid type: Expected number but received NaN"] },
+      error: { item: expect.anything() },
     });
     expect(
       parseWithValibot(createFormData("item2", "non Param"), {
@@ -33,7 +33,7 @@ describe("nonOptional", () => {
       }),
     ).toMatchObject({
       error: {
-        item: ["Invalid type: Expected !undefined but received undefined"],
+        item: expect.anything(),
       },
     });
 
@@ -48,9 +48,7 @@ describe("nonOptional", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          'Invalid type: Expected number | undefined but received "non Number"',
-        ],
+        item: expect.anything(),
       },
     });
     expect(
@@ -59,7 +57,7 @@ describe("nonOptional", () => {
       }),
     ).toMatchObject({
       error: {
-        item: ["Invalid type: Expected !undefined but received undefined"],
+        item: expect.anything(),
       },
     });
   });
@@ -77,13 +75,13 @@ describe("nonOptional", () => {
 
     const output2 = parseWithValibot(createFormData("age", "0"), { schema });
     expect(output2).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
 
     const output3 = parseWithValibot(createFormData("age", ""), { schema });
     expect(output3).toMatchObject({
       error: {
-        age: ["Invalid type: Expected !undefined but received undefined"],
+        age: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/nonOptionalAsync.test.ts
+++ b/tests/coercion/schema/nonOptionalAsync.test.ts
@@ -25,7 +25,7 @@ describe("nonOptionalAsync", () => {
         schema: schema1,
       }),
     ).toMatchObject({
-      error: { item: ["Invalid type: Expected number but received NaN"] },
+      error: { item: expect.anything() },
     });
     expect(
       await parseWithValibot(createFormData("item2", "non Param"), {
@@ -33,7 +33,7 @@ describe("nonOptionalAsync", () => {
       }),
     ).toMatchObject({
       error: {
-        item: ["Invalid type: Expected !undefined but received undefined"],
+        item: expect.anything(),
       },
     });
 
@@ -48,9 +48,7 @@ describe("nonOptionalAsync", () => {
       }),
     ).toMatchObject({
       error: {
-        item: [
-          'Invalid type: Expected number | undefined but received "non Number"',
-        ],
+        item: expect.anything(),
       },
     });
     expect(
@@ -59,7 +57,7 @@ describe("nonOptionalAsync", () => {
       }),
     ).toMatchObject({
       error: {
-        item: ["Invalid type: Expected !undefined but received undefined"],
+        item: expect.anything(),
       },
     });
   });
@@ -81,7 +79,7 @@ describe("nonOptionalAsync", () => {
       schema,
     });
     expect(output2).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
 
     const output3 = await parseWithValibot(createFormData("age", ""), {
@@ -89,7 +87,7 @@ describe("nonOptionalAsync", () => {
     });
     expect(output3).toMatchObject({
       error: {
-        age: ["Invalid type: Expected !undefined but received undefined"],
+        age: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/nullable.test.ts
+++ b/tests/coercion/schema/nullable.test.ts
@@ -23,7 +23,7 @@ describe("nullable", () => {
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received NaN"] },
+      error: { age: expect.anything() },
     });
   });
 
@@ -48,7 +48,7 @@ describe("nullable", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 

--- a/tests/coercion/schema/nullableAsync.test.ts
+++ b/tests/coercion/schema/nullableAsync.test.ts
@@ -25,7 +25,7 @@ describe("nullableAsync", () => {
     expect(
       await parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received NaN"] },
+      error: { age: expect.anything() },
     });
   });
 
@@ -52,7 +52,7 @@ describe("nullableAsync", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 

--- a/tests/coercion/schema/nullish.test.ts
+++ b/tests/coercion/schema/nullish.test.ts
@@ -21,7 +21,7 @@ describe("nullish", () => {
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received NaN"] },
+      error: { age: expect.anything() },
     });
   });
 
@@ -52,7 +52,7 @@ describe("nullish", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 

--- a/tests/coercion/schema/nullishAsync.test.ts
+++ b/tests/coercion/schema/nullishAsync.test.ts
@@ -30,7 +30,7 @@ describe("nullishAsync", () => {
     expect(
       await parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received NaN"] },
+      error: { age: expect.anything() },
     });
   });
 
@@ -65,7 +65,7 @@ describe("nullishAsync", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 

--- a/tests/coercion/schema/number.test.ts
+++ b/tests/coercion/schema/number.test.ts
@@ -12,12 +12,12 @@ describe("number", () => {
     expect(
       parseWithValibot(createFormData("age", ""), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received undefined"] },
+      error: { age: expect.anything() },
     });
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received NaN"] },
+      error: { age: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/object.test.ts
+++ b/tests/coercion/schema/object.test.ts
@@ -26,7 +26,7 @@ describe("object", () => {
     const output3 = parseWithValibot(input2, { schema: schema1 });
     expect(output3).toMatchObject({
       error: {
-        key1: ["Invalid type: Expected string but received undefined"],
+        key1: expect.anything(),
       },
     });
 
@@ -35,7 +35,7 @@ describe("object", () => {
     const output4 = parseWithValibot(input3, { schema: schema1 });
     expect(output4).toMatchObject({
       error: {
-        key2: ["Invalid type: Expected number but received NaN"],
+        key2: expect.anything(),
       },
     });
   });
@@ -64,7 +64,7 @@ describe("object", () => {
     });
     expect(errorOutput).toMatchObject({
       error: {
-        key: ["key is error"],
+        key: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/objectAsync.test.ts
+++ b/tests/coercion/schema/objectAsync.test.ts
@@ -33,7 +33,7 @@ describe("objectAsync", () => {
     const output3 = await parseWithValibot(input2, { schema: schema1 });
     expect(output3).toMatchObject({
       error: {
-        key1: ["Invalid type: Expected string but received undefined"],
+        key1: expect.anything(),
       },
     });
 
@@ -42,7 +42,7 @@ describe("objectAsync", () => {
     const output4 = await parseWithValibot(input3, { schema: schema1 });
     expect(output4).toMatchObject({
       error: {
-        key2: ["Invalid type: Expected number but received NaN"],
+        key2: expect.anything(),
       },
     });
   });
@@ -74,7 +74,7 @@ describe("objectAsync", () => {
     );
     expect(errorOutput).toMatchObject({
       error: {
-        key: ["key is error"],
+        key: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/optional.test.ts
+++ b/tests/coercion/schema/optional.test.ts
@@ -21,7 +21,7 @@ describe("optional", () => {
     expect(
       parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received NaN"] },
+      error: { age: expect.anything() },
     });
   });
 
@@ -52,7 +52,7 @@ describe("optional", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 

--- a/tests/coercion/schema/optionalAsync.test.ts
+++ b/tests/coercion/schema/optionalAsync.test.ts
@@ -30,7 +30,7 @@ describe("optionalAsync", () => {
     expect(
       await parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
-      error: { age: ["Invalid type: Expected number but received NaN"] },
+      error: { age: expect.anything() },
     });
   });
 
@@ -65,7 +65,7 @@ describe("optionalAsync", () => {
       schema,
     });
     expect(errorOutput).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 

--- a/tests/coercion/schema/picklist.test.ts
+++ b/tests/coercion/schema/picklist.test.ts
@@ -25,9 +25,7 @@ describe("picklist", () => {
     const output3 = parseWithValibot(formData3, { schema });
     expect(output3).toMatchObject({
       error: {
-        list: [
-          'Invalid type: Expected "value_1" | "value_2" but received "value_3"',
-        ],
+        list: expect.anything(),
       },
     });
   });

--- a/tests/coercion/schema/string.test.ts
+++ b/tests/coercion/schema/string.test.ts
@@ -16,7 +16,7 @@ describe("string", () => {
     expect(
       parseWithValibot(createFormData("name", ""), { schema }),
     ).toMatchObject({
-      error: { name: ["Invalid type: Expected string but received undefined"] },
+      error: { name: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/tuple.test.ts
+++ b/tests/coercion/schema/tuple.test.ts
@@ -24,11 +24,11 @@ describe("tuple", () => {
 
     const errorInput1 = createFormData("tuple", "1");
     expect(parseWithValibot(errorInput1, { schema: schema1 })).toMatchObject({
-      error: { tuple: ['Invalid type: Expected Array but received "1"'] },
+      error: { tuple: expect.anything() },
     });
     const errorInput2 = createFormData("tuple", "123");
     expect(parseWithValibot(errorInput2, { schema: schema1 })).toMatchObject({
-      error: { tuple: ['Invalid type: Expected Array but received "123"'] },
+      error: { tuple: expect.anything() },
     });
   });
 
@@ -53,7 +53,7 @@ describe("tuple", () => {
     const errorInput = createFormData("tuple", "0");
     errorInput.append("tuple", "test");
     expect(parseWithValibot(errorInput, { schema })).toMatchObject({
-      error: { tuple: ["num is not greater than 0"] },
+      error: { tuple: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/tupleAsync.test.ts
+++ b/tests/coercion/schema/tupleAsync.test.ts
@@ -33,13 +33,13 @@ describe("tupleAsync", () => {
     expect(
       await parseWithValibot(errorInput1, { schema: schema1 }),
     ).toMatchObject({
-      error: { tuple: ['Invalid type: Expected Array but received "1"'] },
+      error: { tuple: expect.anything() },
     });
     const errorInput2 = createFormData("tuple", "123");
     expect(
       await parseWithValibot(errorInput2, { schema: schema1 }),
     ).toMatchObject({
-      error: { tuple: ['Invalid type: Expected Array but received "123"'] },
+      error: { tuple: expect.anything() },
     });
   });
 
@@ -64,7 +64,7 @@ describe("tupleAsync", () => {
     const errorInput = createFormData("tuple", "0");
     errorInput.append("tuple", "test");
     expect(await parseWithValibot(errorInput, { schema })).toMatchObject({
-      error: { tuple: ["num is not greater than 0"] },
+      error: { tuple: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/tupleWithRest.test.ts
+++ b/tests/coercion/schema/tupleWithRest.test.ts
@@ -58,7 +58,7 @@ describe("tupleWithRest", () => {
     const errorInput = createFormData("tuple", "test");
     errorInput.append("tuple", "1");
     expect(parseWithValibot(errorInput, { schema })).toMatchObject({
-      error: { tuple: ["tuple must have more than 1 element"] },
+      error: { tuple: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/tupleWithRestAsync.test.ts
+++ b/tests/coercion/schema/tupleWithRestAsync.test.ts
@@ -61,7 +61,7 @@ describe("tupleWithRestAsync", () => {
     const errorInput = createFormData("tuple", "test");
     errorInput.append("tuple", "1");
     expect(await parseWithValibot(errorInput, { schema })).toMatchObject({
-      error: { tuple: ["tuple must have more than 1 element"] },
+      error: { tuple: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/undefined.test.ts
+++ b/tests/coercion/schema/undefined.test.ts
@@ -21,7 +21,7 @@ describe("undefined", () => {
     const formData2 = createFormData("name", "Jane");
     formData2.append("age", "20");
     expect(parseWithValibot(formData2, { schema })).toMatchObject({
-      error: { age: ['Invalid type: Expected undefined but received "20"'] },
+      error: { age: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/union.test.ts
+++ b/tests/coercion/schema/union.test.ts
@@ -19,9 +19,7 @@ describe("union", () => {
       parseWithValibot(createFormData("age", "non number"), { schema }),
     ).toMatchObject({
       error: {
-        age: [
-          'Invalid type: Expected number | undefined but received "non number"',
-        ],
+        age: expect.anything(),
       },
     });
   });
@@ -51,9 +49,7 @@ describe("union", () => {
     });
     expect(errorOutput1).toMatchObject({
       error: {
-        age: [
-          'Invalid type: Expected number | undefined but received "non number"',
-        ],
+        age: expect.anything(),
       },
     });
 
@@ -61,7 +57,7 @@ describe("union", () => {
       schema,
     });
     expect(errorOutput2).toMatchObject({
-      error: { age: ["age must be greater than 0"] },
+      error: { age: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/variant.test.ts
+++ b/tests/coercion/schema/variant.test.ts
@@ -62,12 +62,12 @@ describe("variant", () => {
 
     const errorInput1 = createFormData("type", "x");
     expect(parseWithValibot(errorInput1, { schema: schema2 })).toMatchObject({
-      error: { type: ['Invalid type: Expected "a" | "b" but received "x"'] },
+      error: { type: expect.anything() },
     });
     const errorInput2 = createFormData("type2", "a");
     expect(parseWithValibot(errorInput2, { schema: schema2 })).toMatchObject({
       error: {
-        type: ['Invalid type: Expected "a" | "b" | "c" but received undefined'],
+        type: expect.anything(),
       },
     });
   });
@@ -106,7 +106,7 @@ describe("variant", () => {
     errorInput1.append("b", "0");
     const errorOutput1 = parseWithValibot(errorInput1, { schema });
     expect(errorOutput1).toMatchObject({
-      error: { b: ["b must be non-zero"] },
+      error: { b: expect.anything() },
     });
   });
 });

--- a/tests/coercion/schema/variantAsync.test.ts
+++ b/tests/coercion/schema/variantAsync.test.ts
@@ -64,14 +64,14 @@ describe("variantAsync", () => {
     expect(
       await parseWithValibot(errorInput1, { schema: schema2 }),
     ).toMatchObject({
-      error: { type: ['Invalid type: Expected "a" | "b" but received "x"'] },
+      error: { type: expect.anything() },
     });
     const errorInput2 = createFormData("type2", "a");
     expect(
       await parseWithValibot(errorInput2, { schema: schema2 }),
     ).toMatchObject({
       error: {
-        type: ['Invalid type: Expected "a" | "b" | "c" but received undefined'],
+        type: expect.anything(),
       },
     });
   });
@@ -110,7 +110,7 @@ describe("variantAsync", () => {
     errorInput1.append("b", "0");
     const errorOutput1 = await parseWithValibot(errorInput1, { schema });
     expect(errorOutput1).toMatchObject({
-      error: { b: ["b must be non-zero"] },
+      error: { b: expect.anything() },
     });
   });
 });


### PR DESCRIPTION
In the test code, we are checking the message output for validation error judgment, but we will change it.

- Since message generation is done by valibot, there is no need for this library to check, so we will change the judgment method.
- The message may be revised when valibot is updated. It is better not to check the contents of the message as it will make the test code unstable.

