### PR TITLE
Nullish schemas should have no required constraint

### DIFF
--- a/constraint.ts
+++ b/constraint.ts
@@ -148,8 +148,8 @@ export function getValibotConstraint<
           // To escape unsafe characters on regex
           typeof option === "string"
             ? option
-              .replace(/[|\\{}()[\]^$+*?.]/g, "\\$&")
-              .replace(/-/g, "\\x2d")
+                .replace(/[|\\{}()[\]^$+*?.]/g, "\\$&")
+                .replace(/-/g, "\\x2d")
             : option,
         )
         .join("|");

--- a/constraint.ts
+++ b/constraint.ts
@@ -120,6 +120,10 @@ export function getValibotConstraint<
       constraint.required = false;
       // @ts-expect-error
       updateConstraint(schema.wrapped, data, name);
+    } else if (schema.type === "nullish") {
+      constraint.required = false;
+      // @ts-expect-error
+      updateConstraint(schema.wrapped, data, name);
     } else if (schema.type === "number") {
       // @ts-expect-error
       const minValue = schema.pipe?.find(
@@ -144,8 +148,8 @@ export function getValibotConstraint<
           // To escape unsafe characters on regex
           typeof option === "string"
             ? option
-                .replace(/[|\\{}()[\]^$+*?.]/g, "\\$&")
-                .replace(/-/g, "\\x2d")
+              .replace(/[|\\{}()[\]^$+*?.]/g, "\\$&")
+              .replace(/-/g, "\\x2d")
             : option,
         )
         .join("|");

--- a/tests/constraint.test.ts
+++ b/tests/constraint.test.ts
@@ -11,6 +11,7 @@ import {
   maxValue,
   minLength,
   minValue,
+  nullish,
   number,
   object,
   optional,
@@ -83,6 +84,7 @@ describe("constraint", () => {
           pipe(string(), minLength(3, "min")),
           optional(pipe(number(), maxValue(100, "max"))),
         ]),
+        nullishString: nullish(string())
       }),
       check(() => false, "refine"),
     );
@@ -145,6 +147,9 @@ describe("constraint", () => {
         required: false,
         max: 100,
       },
+      nullishString: {
+        required: false,
+      }
     };
 
     expect(getValibotConstraint(schema)).toEqual(constraint);

--- a/tests/constraint.test.ts
+++ b/tests/constraint.test.ts
@@ -84,7 +84,7 @@ describe("constraint", () => {
           pipe(string(), minLength(3, "min")),
           optional(pipe(number(), maxValue(100, "max"))),
         ]),
-        nullishString: nullish(string())
+        nullishString: nullish(string()),
       }),
       check(() => false, "refine"),
     );
@@ -149,7 +149,7 @@ describe("constraint", () => {
       },
       nullishString: {
         required: false,
-      }
+      },
     };
 
     expect(getValibotConstraint(schema)).toEqual(constraint);


### PR DESCRIPTION
@chimame Hey there. Could you please check the PR? I'm adding support for nullish constraints. Right now nullish props are flagged as `required`. this PR aims to fix that.
Didn't find a contribution guide so maybe let me know if this PR isn't exactly what you were hoping for :)