### PR TITLE
Use empty path for top-level form errors

### DIFF
--- a/parse.ts
+++ b/parse.ts
@@ -71,7 +71,7 @@ export function parseWithValibot<
           error: result.issues.reduce<Record<string, string[]>>((result, e) => {
             const name = formatPaths(
               // @ts-expect-error
-              e.path?.map((d) => d.key as string | number) ?? []
+              e.path?.map((d) => d.key as string | number) ?? [],
             );
 
             result[name] = [...(result[name] ?? []), e.message];

--- a/parse.ts
+++ b/parse.ts
@@ -69,10 +69,10 @@ export function parseWithValibot<
 
         return {
           error: result.issues.reduce<Record<string, string[]>>((result, e) => {
-            const name = e.path
-              ? // @ts-expect-error
-                formatPaths(e.path.map((d) => d.key as string | number))
-              : (e.input as string | number);
+            const name = formatPaths(
+              // @ts-expect-error
+              e.path?.map((d) => d.key as string | number) ?? []
+            );
 
             result[name] = [...(result[name] ?? []), e.message];
 

--- a/tests/coercion/schema/object.test.ts
+++ b/tests/coercion/schema/object.test.ts
@@ -70,4 +70,27 @@ describe("object", () => {
       },
     });
   });
+
+  test("should fail with check on object", () => {
+    const schema = pipe(
+      object({
+        key1: string(),
+        key2: string(),
+      }),
+      check(({ key1, key2 }) => key1 === key2, "keys must match"),
+    );
+
+    const input = createFormData("key1", "foo");
+    input.append("key2", "bar");
+
+    const errorOutput = parseWithValibot(input, {
+      schema,
+    });
+
+    expect(errorOutput).toMatchObject({
+      error: {
+        "": ["keys must match"],
+      },
+    });
+  });
 });

--- a/tests/coercion/schema/objectAsync.test.ts
+++ b/tests/coercion/schema/objectAsync.test.ts
@@ -80,4 +80,27 @@ describe("objectAsync", () => {
       },
     });
   });
+
+  test("should fail with check on object", async () => {
+    const schema = pipeAsync(
+      objectAsync({
+        key1: string(),
+        key2: string(),
+      }),
+      checkAsync(({ key1, key2 }) => key1 === key2, "keys must match"),
+    );
+
+    const input = createFormData("key1", "foo");
+    input.append("key2", "bar");
+
+    const errorOutput = await parseWithValibot(input, {
+      schema,
+    });
+
+    expect(errorOutput).toMatchObject({
+      error: {
+        "": ["keys must match"],
+      },
+    });
+  });
 });


### PR DESCRIPTION
Closes #42 