### PR TITLE
fix: Cannot be validated correctly when nested pipe schema exists

### DIFF
--- a/parse.ts
+++ b/parse.ts
@@ -54,7 +54,7 @@ export function parseWithValibot<
         typeof config.schema === "function"
           ? config.schema(intent)
           : config.schema;
-      const schema = enableTypeCoercion(originalSchema);
+      const { schema } = enableTypeCoercion(originalSchema);
 
       const resolveResult = (
         result: SafeParseResult<Schema>,

--- a/tests/coercion/schema/wrap.test.ts
+++ b/tests/coercion/schema/wrap.test.ts
@@ -1,4 +1,12 @@
-import { nullable, object, optional, string } from "valibot";
+import {
+  check,
+  isoDate,
+  nullable,
+  object,
+  optional,
+  pipe,
+  string,
+} from "valibot";
 import { describe, expect, test } from "vitest";
 import { parseWithValibot } from "../../../parse";
 import { createFormData } from "../../helpers/FormData";
@@ -8,5 +16,31 @@ describe("wrap", () => {
     const schema = object({ name: optional(nullable(string()), null) });
     const output = parseWithValibot(createFormData("name", ""), { schema });
     expect(output).toMatchObject({ status: "success", value: { name: null } });
+  });
+
+  test("should pass with nested pipe object", () => {
+    const schema = object({
+      key1: string(),
+      key2: optional(
+        pipe(
+          object({
+            date: optional(pipe(string(), isoDate())),
+          }),
+          check((input) => input?.date !== "2000-01-01", "Bad date"),
+        ),
+      ),
+    });
+
+    const input = createFormData("key1", "valid");
+    input.append("key2.date", "");
+
+    const output = parseWithValibot(input, {
+      schema,
+    });
+
+    expect(output).toMatchObject({
+      status: "success",
+      value: { key1: "valid", key2: {} },
+    });
   });
 });

--- a/tests/coercion/schema/wrapAsync.test.ts
+++ b/tests/coercion/schema/wrapAsync.test.ts
@@ -1,4 +1,12 @@
-import { nullableAsync, objectAsync, optionalAsync, string } from "valibot";
+import {
+  checkAsync,
+  isoDate,
+  nullableAsync,
+  objectAsync,
+  optionalAsync,
+  pipeAsync,
+  string,
+} from "valibot";
 import { describe, expect, test } from "vitest";
 import { parseWithValibot } from "../../../parse";
 import { createFormData } from "../../helpers/FormData";
@@ -12,5 +20,31 @@ describe("wrapAsync", () => {
       schema,
     });
     expect(output).toMatchObject({ status: "success", value: { name: null } });
+  });
+
+  test("should pass with nested pipe object", async () => {
+    const schema = objectAsync({
+      key1: string(),
+      key2: optionalAsync(
+        pipeAsync(
+          objectAsync({
+            date: optionalAsync(pipeAsync(string(), isoDate())),
+          }),
+          checkAsync((input) => input?.date !== "2000-01-01", "Bad date"),
+        ),
+      ),
+    });
+
+    const input = createFormData("key1", "valid");
+    input.append("key2.date", "");
+
+    const output = await parseWithValibot(input, {
+      schema,
+    });
+
+    expect(output).toMatchObject({
+      status: "success",
+      value: { key1: "valid", key2: {} },
+    });
   });
 });


### PR DESCRIPTION
Close #44 

## Description

The problem in #44 occurs because there is code that determines whether the `pipe` schema is being used. The reason why the `pipe` schema is being used is because, when `optional(string())` is present, the `string()` part is used to determine whether a `pipe` process is being performed to convert data before validation, such as `pipe(unkown(), function coerce, string())`.
The problem occurred because the determination of whether the `pipe` schema is being used is indistinguishable from the `pipe` schema defined by the user.

The code will be modified to use `function coerce`, that is, a flag that returns whether a forced conversion process is being performed to determine whether the value is being converted, so that the `pipe` schema can be used safely.