### PR TITLE
Allow users to skip validation or to fallback to server validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,104 @@ export async function action({ request }) {
 }
 ```
 
+You can skip an validation to use the previous result. On client validation, you can indicate the validation is not defined to fallback to server validation.
+
+```tsx
+import type { Intent } from "@conform-to/react";
+import { useForm } from '@conform-to/react';
+import { parseWithValibot } from 'conform-to-valibot';
+import {
+  check,
+  forward,
+  forwardAsync,
+  object,
+  partialCheck,
+  partialCheckAsync,
+  pipe,
+  pipeAsync,
+  string,
+} from "valibot";
+
+function createBaseSchema(intent: Intent | null) {
+  return object({
+    email: pipe(
+      string("Email is required"),
+      // When not validating email, leave the email error as it is.
+      check(
+        () =>
+          intent === null ||
+          (intent.type === "validate" && intent.payload.name === "email"),
+        conformValibotMessage.VALIDATION_SKIPPED,
+      ),
+    ),
+    password: string("Password is required"),
+  });
+}
+
+function createServerSchema(
+  intent: Intent | null,
+  options: { isEmailUnique: (email: string) => Promise<boolean> },
+) {
+  return pipeAsync(
+    createBaseSchema(intent),
+    forwardAsync(
+      partialCheckAsync(
+        [["email"]],
+        async ({ email }) => options.isEmailUnique(email),
+        "Email is already used",
+      ),
+      ["email"],
+    ),
+  );
+}
+
+function createClientSchema(intent: Intent | null) {
+  return pipe(
+    createBaseSchema(intent),
+    forward(
+      // If email is specified, fallback to server validation to check its uniqueness.
+      partialCheck(
+        [["email"]],
+        () => false,
+        conformValibotMessage.VALIDATION_UNDEFINED,
+      ),
+      ["email"],
+    ),
+  );
+}
+
+export async function action({ request }) {
+  const formData = await request.formData();
+  const submission = await parseWithValibot(formData, {
+    schema: (intent) =>
+      createServerSchema(intent, {
+        isEmailUnique: async (email) => {
+          // Query your database to check if the email is unique
+        },
+      }),
+  });
+
+  // Send the submission back to the client if the status is not successful
+  if (submission.status !== "success") {
+    return submission.reply();
+  }
+
+  // ...
+}
+
+function ExampleForm() {
+  const [form, { email, password }] = useForm({
+    onValidate({ formData }) {
+      return parseWithValibot(formData, {
+        schema: (intent) => createClientSchema(intent),
+      });
+    },
+  });
+
+  // ...
+}
+```
+
 ### getValibotConstraint
 
 A helper that returns an object containing the validation attributes for each field by introspecting the valibot schema.

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,2 @@
 export { getValibotConstraint } from "./constraint";
-export { parseWithValibot } from "./parse";
+export { conformValibotMessage, parseWithValibot } from "./parse";

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -1,0 +1,38 @@
+import { check, object, pipe, string } from "valibot";
+import { describe, expect, test } from "vitest";
+import { conformValibotMessage, parseWithValibot } from "../parse";
+import { createFormData } from "./helpers/FormData";
+
+describe("parseWithValibot", () => {
+  test("should return null for an error field when its error message is skipped", () => {
+    const schema = object({
+      key: pipe(
+        string(),
+        check(
+          (input) => input === "valid",
+          conformValibotMessage.VALIDATION_SKIPPED,
+        ),
+      ),
+    });
+    const output = parseWithValibot(createFormData("key", "invalid"), {
+      schema,
+    });
+    expect(output).toMatchObject({ error: { key: null } });
+  });
+
+  test("should return null for the error when any error message is undefined", () => {
+    const schema = object({
+      key: pipe(
+        string(),
+        check(
+          (input) => input === "valid",
+          conformValibotMessage.VALIDATION_UNDEFINED,
+        ),
+      ),
+    });
+    const output = parseWithValibot(createFormData("key", "invalid"), {
+      schema,
+    });
+    expect(output).toMatchObject({ error: null });
+  });
+});


### PR DESCRIPTION
`@conform-to/zod` allows user to skip validation or to fallback to server validation: [conform/docs/api/zod/conformZodMessage.md at main · edmundhung/conform](https://github.com/edmundhung/conform/blob/main/docs/api/zod/conformZodMessage.md).

It is very helpful if conform-to-valibot also supports these features.