### PR TITLE
fix: Validation correctly even when the `optional` and `nullish` keys are not specified

### DIFF
--- a/tests/coercion/schema/nullish.test.ts
+++ b/tests/coercion/schema/nullish.test.ts
@@ -5,7 +5,7 @@ import { createFormData } from "../../helpers/FormData";
 
 describe("nullish", () => {
   test("should pass also undefined", () => {
-    const schema = object({ age: nullish(number()) });
+    const schema = object({ name: nullish(string()), age: nullish(number()) });
     const output = parseWithValibot(createFormData("age", ""), { schema });
 
     expect(output).toMatchObject({

--- a/tests/coercion/schema/nullishAsync.test.ts
+++ b/tests/coercion/schema/nullishAsync.test.ts
@@ -12,7 +12,10 @@ import { createFormData } from "../../helpers/FormData";
 
 describe("nullishAsync", () => {
   test("should pass also undefined", async () => {
-    const schema = objectAsync({ age: nullishAsync(number()) });
+    const schema = objectAsync({
+      name: nullishAsync(string()),
+      age: nullishAsync(number()),
+    });
     const output = await parseWithValibot(createFormData("age", ""), {
       schema,
     });

--- a/tests/coercion/schema/optional.test.ts
+++ b/tests/coercion/schema/optional.test.ts
@@ -5,7 +5,10 @@ import { createFormData } from "../../helpers/FormData";
 
 describe("optional", () => {
   test("should pass also undefined", () => {
-    const schema = object({ age: optional(number()) });
+    const schema = object({
+      name: optional(string()),
+      age: optional(number()),
+    });
     const output = parseWithValibot(createFormData("age", ""), { schema });
 
     expect(output).toMatchObject({

--- a/tests/coercion/schema/optionalAsync.test.ts
+++ b/tests/coercion/schema/optionalAsync.test.ts
@@ -12,7 +12,10 @@ import { createFormData } from "../../helpers/FormData";
 
 describe("optionalAsync", () => {
   test("should pass also undefined", async () => {
-    const schema = objectAsync({ age: optionalAsync(number()) });
+    const schema = objectAsync({
+      name: optionalAsync(string()),
+      age: optionalAsync(number()),
+    });
     const output = await parseWithValibot(createFormData("age", ""), {
       schema,
     });


### PR DESCRIPTION
Close #53

One concern with this PR is that since `nullish` and `optional` are imported, the bundle size is likely to increase slightly.