### PR TITLE
fix: Allow pipes to be nested directly within other pipes

### DIFF
--- a/coercion.ts
+++ b/coercion.ts
@@ -253,7 +253,19 @@ export function enableTypeCoercion<
             [T, ...PipeItem<unknown, unknown, BaseIssue<unknown>>[]]
           >);
 } {
-  const originalSchema = "pipe" in type ? type.pipe[0] : type;
+  if ("pipe" in type) {
+    const { transformAction, schema: coercedSchema } = enableTypeCoercion(
+      type.pipe[0],
+    );
+    const schema = type.async
+      ? pipeAsync(coercedSchema, ...type.pipe.slice(1))
+      : // @ts-expect-error `coercedSchema` must be sync here but TypeScript can't infer that.
+        pipe(coercedSchema, ...type.pipe.slice(1));
+
+    return { transformAction, schema };
+  }
+
+  const originalSchema = type;
 
   switch (type.type) {
     case "string":

--- a/tests/coercion/schema/wrap.test.ts
+++ b/tests/coercion/schema/wrap.test.ts
@@ -2,6 +2,7 @@ import {
   check,
   isoDate,
   nullable,
+  number,
   object,
   optional,
   pipe,
@@ -41,6 +42,44 @@ describe("wrap", () => {
     expect(output).toMatchObject({
       status: "success",
       value: { key1: "valid", key2: {} },
+    });
+  });
+
+  test("should pass with directly nested pipe object", () => {
+    const schema = pipe(
+      pipe(
+        object({
+          key: number(),
+        }),
+        check(({ key }) => key > 0, "key is not positive"),
+      ),
+      check(({ key }) => key % 2 === 0, "key is not even"),
+    );
+
+    const output = parseWithValibot(createFormData("key", "2"), {
+      schema,
+    });
+    expect(output).toMatchObject({
+      status: "success",
+      value: { key: 2 },
+    });
+
+    const errorOutput1 = parseWithValibot(createFormData("key", "-2"), {
+      schema,
+    });
+    expect(errorOutput1).toMatchObject({
+      error: {
+        "": ["key is not positive"],
+      },
+    });
+
+    const errorOutput2 = parseWithValibot(createFormData("key", "1"), {
+      schema,
+    });
+    expect(errorOutput2).toMatchObject({
+      error: {
+        "": ["key is not even"],
+      },
     });
   });
 });

--- a/tests/coercion/schema/wrapAsync.test.ts
+++ b/tests/coercion/schema/wrapAsync.test.ts
@@ -3,6 +3,7 @@ import {
   isoDate,
   nullableAsync,
   number,
+  object,
   objectAsync,
   optionalAsync,
   pipeAsync,
@@ -84,6 +85,23 @@ describe("wrapAsync", () => {
       error: {
         "": ["key is not even"],
       },
+    });
+  });
+
+  test("should pass sync object with async pipe", async () => {
+    const schema = pipeAsync(
+      object({
+        key: string(),
+      }),
+      checkAsync(async ({ key }) => key !== "error name", "key is error"),
+    );
+
+    const output = await parseWithValibot(createFormData("key", "valid"), {
+      schema,
+    });
+    expect(output).toMatchObject({
+      status: "success",
+      value: { key: "valid" },
     });
   });
 });

--- a/tests/coercion/schema/wrapAsync.test.ts
+++ b/tests/coercion/schema/wrapAsync.test.ts
@@ -2,6 +2,7 @@ import {
   checkAsync,
   isoDate,
   nullableAsync,
+  number,
   objectAsync,
   optionalAsync,
   pipeAsync,
@@ -45,6 +46,44 @@ describe("wrapAsync", () => {
     expect(output).toMatchObject({
       status: "success",
       value: { key1: "valid", key2: {} },
+    });
+  });
+
+  test("should pass with directly nested pipe object", async () => {
+    const schema = pipeAsync(
+      pipeAsync(
+        objectAsync({
+          key: number(),
+        }),
+        checkAsync(({ key }) => key > 0, "key is not positive"),
+      ),
+      checkAsync(({ key }) => key % 2 === 0, "key is not even"),
+    );
+
+    const output = await parseWithValibot(createFormData("key", "2"), {
+      schema,
+    });
+    expect(output).toMatchObject({
+      status: "success",
+      value: { key: 2 },
+    });
+
+    const errorOutput1 = await parseWithValibot(createFormData("key", "-2"), {
+      schema,
+    });
+    expect(errorOutput1).toMatchObject({
+      error: {
+        "": ["key is not positive"],
+      },
+    });
+
+    const errorOutput2 = await parseWithValibot(createFormData("key", "1"), {
+      schema,
+    });
+    expect(errorOutput2).toMatchObject({
+      error: {
+        "": ["key is not even"],
+      },
     });
   });
 });


### PR DESCRIPTION
conform-to-valibot fails to coerce schemas with directly nested pipes. This pull request changes coercion process to handle those schemas.

Fix #56 
Fix #55 
