### PR TITLE
docs: add deprecated comments

### DIFF
--- a/coercion.ts
+++ b/coercion.ts
@@ -12,6 +12,19 @@ import {
   unknown as valibotUnknown,
 } from "valibot";
 
+/**
+ * @deprecated The official valibot support
+ * [library](https://www.npmjs.com/package/@conform-to/valibot)
+ * based on this library has been released.
+ *
+ * This project will be archived in the near future.
+ *
+ * To migrate, just install the official library
+ * ( `npm install @conform-to/valibot` )
+ * and change the reference.
+ *
+ * @see https://www.npmjs.com/package/@conform-to/valibot
+ */
 export type CoercionFunction = (value: unknown) => unknown;
 
 export type DefaultCoercionType =
@@ -454,6 +467,18 @@ function enableTypeCoercion<T extends GenericSchema | GenericSchemaAsync>(
 }
 
 /**
+ * @deprecated The official valibot support
+ * [library](https://www.npmjs.com/package/@conform-to/valibot)
+ * based on this library has been released.
+ *
+ * This project will be archived in the near future.
+ *
+ * To migrate, just install the official library
+ * ( `npm install @conform-to/valibot` )
+ * and change the reference.
+ *
+ * @see https://www.npmjs.com/package/@conform-to/valibot
+ *
  * A helper that enhance the valibot schema to strip empty value and coerce form value to the expected type with option to customize type coercion.
  * @example
  *

--- a/constraint.ts
+++ b/constraint.ts
@@ -12,6 +12,19 @@ const keys: Array<keyof Constraint> = [
   "pattern",
 ];
 
+/**
+ * @deprecated The official valibot support
+ * [library](https://www.npmjs.com/package/@conform-to/valibot)
+ * based on this library has been released.
+ *
+ * This project will be archived in the near future.
+ *
+ * To migrate, just install the official library
+ * ( `npm install @conform-to/valibot` )
+ * and change the reference.
+ *
+ * @see https://www.npmjs.com/package/@conform-to/valibot
+ */
 export function getValibotConstraint<
   T extends GenericSchema | GenericSchemaAsync,
 >(schema: T): Record<string, Constraint> {

--- a/parse.ts
+++ b/parse.ts
@@ -16,6 +16,19 @@ import {
 } from "valibot";
 import { coerceFormValue } from "./coercion";
 
+/**
+ * @deprecated The official valibot support
+ * [library](https://www.npmjs.com/package/@conform-to/valibot)
+ * based on this library has been released.
+ *
+ * This project will be archived in the near future.
+ *
+ * To migrate, just install the official library
+ * ( `npm install @conform-to/valibot` )
+ * and change the reference.
+ *
+ * @see https://www.npmjs.com/package/@conform-to/valibot
+ */
 export const conformValibotMessage = {
   VALIDATION_SKIPPED: "__skipped__",
   VALIDATION_UNDEFINED: "__undefined__",
@@ -23,6 +36,19 @@ export const conformValibotMessage = {
 
 type ErrorType = Record<string, string[] | null> | null;
 
+/**
+ * @deprecated The official valibot support
+ * [library](https://www.npmjs.com/package/@conform-to/valibot)
+ * based on this library has been released.
+ *
+ * This project will be archived in the near future.
+ *
+ * To migrate, just install the official library
+ * ( `npm install @conform-to/valibot` )
+ * and change the reference.
+ *
+ * @see https://www.npmjs.com/package/@conform-to/valibot
+ */
 export function parseWithValibot<Schema extends GenericSchema>(
   payload: FormData | URLSearchParams,
   config: {
@@ -34,6 +60,19 @@ export function parseWithValibot<Schema extends GenericSchema>(
     >;
   },
 ): Submission<InferOutput<Schema>>;
+/**
+ * @deprecated The official valibot support
+ * [library](https://www.npmjs.com/package/@conform-to/valibot)
+ * based on this library has been released.
+ *
+ * This project will be archived in the near future.
+ *
+ * To migrate, just install the official library
+ * ( `npm install @conform-to/valibot` )
+ * and change the reference.
+ *
+ * @see https://www.npmjs.com/package/@conform-to/valibot
+ */
 export function parseWithValibot<Schema extends GenericSchemaAsync>(
   payload: FormData | URLSearchParams,
   config: {
@@ -45,6 +84,19 @@ export function parseWithValibot<Schema extends GenericSchemaAsync>(
     >;
   },
 ): Promise<Submission<InferOutput<Schema>>>;
+/**
+ * @deprecated The official valibot support
+ * [library](https://www.npmjs.com/package/@conform-to/valibot)
+ * based on this library has been released.
+ *
+ * This project will be archived in the near future.
+ *
+ * To migrate, just install the official library
+ * ( `npm install @conform-to/valibot` )
+ * and change the reference.
+ *
+ * @see https://www.npmjs.com/package/@conform-to/valibot
+ */
 export function parseWithValibot<
   Schema extends GenericSchema | GenericSchemaAsync,
 >(


### PR DESCRIPTION
Since the library itself has been deprecated, I've added deprecation comments to all exported elements.

This will help users become aware of the deprecation when using IDEs such as VSCode.

For reference, I've attached a screenshot from VSCode showing how these comments appear when applied.
<img width="943" alt="image" src="https://github.com/user-attachments/assets/8b0bf538-9a2a-44bc-b3bf-abfabf0100b5" />
